### PR TITLE
2026 Design Updates: Phase 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ next-env.d.ts
 # vscode
 .vscode
 certificates
+
+# cursor
+.cursor/debug-*.log

--- a/src/app/about/page.test.tsx
+++ b/src/app/about/page.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react'
+import AboutPage from './page'
+
+jest.mock('@/lib/contentful', () => ({
+  getSkills: jest.fn(),
+  getReferences: jest.fn(),
+  getPositions: jest.fn(),
+}))
+
+const { getSkills, getReferences, getPositions } = jest.requireMock<{
+  getSkills: jest.Mock
+  getReferences: jest.Mock
+  getPositions: jest.Mock
+}>('@/lib/contentful')
+
+jest.mock('@/components/Skills', () => {
+  return function MockSkills({ skills }: { skills: unknown[] }) {
+    return <div data-testid="skills">Skills: {skills.length}</div>
+  }
+})
+
+jest.mock('@/components/Positions', () => {
+  return function MockPositions({ positions }: { positions: unknown[] }) {
+    return <div data-testid="positions">Positions: {positions.length}</div>
+  }
+})
+
+jest.mock('@/components/References', () => {
+  return function MockReferences({ references }: { references: unknown[] }) {
+    return <div data-testid="references">References: {references.length}</div>
+  }
+})
+
+jest.mock('@/components/Icon', () => {
+  return function MockIcon({ type }: { type: string }) {
+    return <span data-testid={`icon-${type}`}>{type}</span>
+  }
+})
+
+jest.mock('lucide-react', () => ({
+  ExternalLink: () => (
+    <span data-testid="external-link-icon">ExternalLink</span>
+  ),
+}))
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) {
+    return <a href={href}>{children}</a>
+  }
+})
+
+jest.mock('@/styles/common', () => ({
+  StyledContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="container">{children}</div>
+  ),
+  StyledIntroParagraph: ({ children }: { children: React.ReactNode }) => (
+    <p data-testid="intro-paragraph">{children}</p>
+  ),
+  StyledList: ({ children }: { children: React.ReactNode }) => (
+    <ul data-testid="list">{children}</ul>
+  ),
+  StyledListItem: ({ children }: { children: React.ReactNode }) => (
+    <li data-testid="list-item">{children}</li>
+  ),
+  StyledSection: ({
+    children,
+    id,
+  }: {
+    children: React.ReactNode
+    id?: string
+  }) => (
+    <section data-testid="section" id={id}>
+      {children}
+    </section>
+  ),
+  StyledLink: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode
+    href: string
+    [key: string]: unknown
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+  StyledBreadcrumb: ({ children }: { children: React.ReactNode }) => (
+    <nav data-testid="breadcrumb" aria-label="Breadcrumb">
+      {children}
+    </nav>
+  ),
+}))
+
+describe('About page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getSkills.mockResolvedValue([{ name: 'A' }, { name: 'B' }])
+    getPositions.mockResolvedValue([{ company: 'Acme' }])
+    getReferences.mockResolvedValue([{ citeName: 'Jane' }])
+  })
+
+  it('renders a single h1 about Jason', async () => {
+    const pageComponent = await AboutPage()
+    render(pageComponent)
+
+    const headings = screen.getAllByRole('heading', { level: 1 })
+    expect(headings).toHaveLength(1)
+    expect(headings[0]).toHaveTextContent(/about jason rundell/i)
+  })
+
+  it('renders intro, skills, experience and recommendations sections', async () => {
+    const pageComponent = await AboutPage()
+    render(pageComponent)
+
+    expect(screen.getByTestId('intro-paragraph')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: /^skills$/i })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('skills')).toHaveTextContent('Skills: 2')
+    expect(
+      screen.getByRole('heading', { name: /^experience$/i })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('positions')).toHaveTextContent('Positions: 1')
+    expect(
+      screen.getByRole('heading', { name: /^recommendations$/i })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('references')).toHaveTextContent('References: 1')
+  })
+
+  it('includes a LinkedIn link in the experience section', async () => {
+    const pageComponent = await AboutPage()
+    render(pageComponent)
+
+    const linkedinLink = screen.getByRole('link', {
+      name: /see more on linkedin/i,
+    })
+    expect(linkedinLink).toHaveAttribute(
+      'href',
+      'https://www.linkedin.com/in/jasonrundell/'
+    )
+  })
+
+  it('renders Person JSON-LD structured data', async () => {
+    const pageComponent = await AboutPage()
+    const { container } = render(pageComponent)
+
+    const ld = container.querySelector('script[type="application/ld+json"]')
+    expect(ld).toBeInTheDocument()
+
+    const parsed = JSON.parse(ld?.textContent ?? '{}')
+    expect(parsed['@type']).toBe('Person')
+    expect(parsed.name).toBe('Jason Rundell')
+    expect(parsed.sameAs).toEqual(
+      expect.arrayContaining([
+        'https://www.linkedin.com/in/jasonrundell/',
+        'https://github.com/jasonrundell',
+      ])
+    )
+  })
+})

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import { ExternalLink } from 'lucide-react'
+import Link from 'next/link'
+import { Row, Spacer } from '@jasonrundell/dropship'
+
+import {
+  getSkills,
+  getReferences,
+  getPositions,
+} from '@/lib/contentful'
+
+import {
+  StyledContainer,
+  StyledIntroParagraph,
+  StyledList,
+  StyledListItem,
+  StyledSection,
+  StyledLink,
+  StyledBreadcrumb,
+} from '@/styles/common'
+
+import Skills from '@/components/Skills'
+import References from '@/components/References'
+import Positions from '@/components/Positions'
+import Icon from '@/components/Icon'
+import { buildPersonJsonLd } from '@/lib/jsonld'
+
+export const metadata = {
+  title: 'About | Jason Rundell',
+  description:
+    'About Jason Rundell — manager, full-stack developer, skills, experience, and recommendations.',
+}
+
+export const revalidate = 86400
+
+const personJsonLd = buildPersonJsonLd()
+
+export default async function AboutPage() {
+  const [skills, references, positions] = await Promise.all([
+    getSkills(),
+    getReferences(),
+    getPositions(),
+  ])
+
+  return (
+    <StyledContainer>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+      />
+      <StyledSection id="about">
+        <StyledBreadcrumb>
+          <Link href="/">Home</Link> &gt; About
+        </StyledBreadcrumb>
+        <h1>About Jason Rundell</h1>
+        <Row>
+          <StyledIntroParagraph>
+            Hi! I&apos;m an AI-first Application Development Manager and Senior
+            Full Stack Web Developer with 20+ years leading high-impact web
+            platforms and engineering teams. Skilled at modernizing legacy
+            systems into scalable web applications, integrating AI into
+            workflows and products, and aligning delivery with business goals.
+          </StyledIntroParagraph>
+          <p>
+            My passion for creating web experiences began in my high
+            school&apos;s library back in 1997 when I discovered GeoCities.
+            Since then, I&apos;ve been fortunate to work on a diverse range of
+            projects spanning multiple technologies, including iframes, Flash,
+            WordPress multisites, jQuery Mobile, custom CMS applications, a
+            Facebook contest platform, React design systems, Jamstack
+            architecture, and most recently, exploration of the possibilities
+            and limitations of automation, and AI.
+          </p>
+          <p>
+            I&apos;m constantly exploring new trends and experimenting with
+            emerging technologies in my spare time to expand my skills and
+            knowledge. As a lifelong learner, I embrace change, seek out
+            challenges, and thrive on the fast-paced nature of the tech
+            industry. After 20 years, I still love working on the web!
+          </p>
+        </Row>
+      </StyledSection>
+
+      <StyledSection id="skills">
+        <h2>Skills</h2>
+        <Row>{skills && <Skills skills={skills} />}</Row>
+      </StyledSection>
+
+      <StyledSection id="experience">
+        <h2>Experience</h2>
+        <Row>
+          {positions.length > 0 && <Positions positions={positions} />}
+        </Row>
+        <Spacer />
+        <Row>
+          <StyledList>
+            <StyledListItem>
+              <Icon type="LinkedIn" />{' '}
+              <StyledLink
+                href="https://www.linkedin.com/in/jasonrundell/"
+                rel="noopener noreferrer"
+                target="_blank"
+                aria-label="See more on LinkedIn"
+              >
+                <ExternalLink size={18} /> See more on LinkedIn
+              </StyledLink>
+            </StyledListItem>
+          </StyledList>
+        </Row>
+      </StyledSection>
+
+      <StyledSection id="recommendations">
+        <h2>Recommendations</h2>
+        <Row>
+          {references.length > 0 && <References references={references} />}
+        </Row>
+      </StyledSection>
+    </StyledContainer>
+  )
+}

--- a/src/app/contact/page.test.tsx
+++ b/src/app/contact/page.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import ContactPage from './page'
+
+jest.mock('@/components/ContactList', () => {
+  return function MockContactList() {
+    return <div data-testid="contact-list">Contact List</div>
+  }
+})
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) {
+    return <a href={href}>{children}</a>
+  }
+})
+
+jest.mock('@/styles/common', () => ({
+  StyledContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="container">{children}</div>
+  ),
+  StyledSection: ({
+    children,
+    id,
+  }: {
+    children: React.ReactNode
+    id?: string
+  }) => (
+    <section data-testid="section" id={id}>
+      {children}
+    </section>
+  ),
+  StyledBreadcrumb: ({ children }: { children: React.ReactNode }) => (
+    <nav data-testid="breadcrumb" aria-label="Breadcrumb">
+      {children}
+    </nav>
+  ),
+}))
+
+describe('Contact page', () => {
+  it('renders a single h1', () => {
+    render(<ContactPage />)
+
+    const headings = screen.getAllByRole('heading', { level: 1 })
+    expect(headings).toHaveLength(1)
+    expect(headings[0]).toHaveTextContent(/contact me/i)
+  })
+
+  it('renders the contact list', () => {
+    render(<ContactPage />)
+
+    expect(screen.getByTestId('contact-list')).toBeInTheDocument()
+  })
+
+  it('renders a breadcrumb to home', () => {
+    render(<ContactPage />)
+
+    expect(screen.getByRole('link', { name: /^home$/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+})

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import Link from 'next/link'
+import { Row, Spacer } from '@jasonrundell/dropship'
+
+import {
+  StyledContainer,
+  StyledSection,
+  StyledBreadcrumb,
+} from '@/styles/common'
+import ContactList from '@/components/ContactList'
+
+export const metadata = {
+  title: 'Contact | Jason Rundell',
+  description:
+    'Get in touch with Jason Rundell — email, LinkedIn, GitHub, and a calendar link to book time.',
+}
+
+export const revalidate = 86400
+
+export default function ContactPage() {
+  return (
+    <StyledContainer>
+      <StyledSection id="contact-page">
+        <StyledBreadcrumb>
+          <Link href="/">Home</Link> &gt; Contact
+        </StyledBreadcrumb>
+        <h1>Contact me</h1>
+        <Row>
+          <p>
+            The fastest way to reach me is email. For longer conversations, book
+            time on the calendar or connect on LinkedIn.
+          </p>
+        </Row>
+        <Spacer />
+        <Row>
+          <ContactList />
+        </Row>
+      </StyledSection>
+    </StyledContainer>
+  )
+}

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,48 +1,15 @@
 import { render, screen } from '@testing-library/react'
 import Page from './page'
 
-// Mock Contentful functions
 jest.mock('@/lib/contentful', () => ({
-  getSkills: jest.fn(),
   getProjects: jest.fn(),
-  getReferences: jest.fn(),
-  getPositions: jest.fn(),
   getPosts: jest.fn(),
 }))
 
-const { getSkills, getProjects, getReferences, getPositions, getPosts } =
-  jest.requireMock<{
-    getSkills: jest.Mock
-    getProjects: jest.Mock
-    getReferences: jest.Mock
-    getPositions: jest.Mock
-    getPosts: jest.Mock
-  }>('@/lib/contentful')
-
-// Mock components
-jest.mock('@/components/Skills', () => {
-  return function MockSkills({ skills }: { skills: unknown[] }) {
-    return <div data-testid="skills">Skills: {skills.length}</div>
-  }
-})
-
-jest.mock('@/components/ContactList', () => {
-  return function MockContactList() {
-    return <div data-testid="contact-list">Contact List</div>
-  }
-})
-
-jest.mock('@/components/References', () => {
-  return function MockReferences({ references }: { references: unknown[] }) {
-    return <div data-testid="references">References: {references.length}</div>
-  }
-})
-
-jest.mock('@/components/Positions', () => {
-  return function MockPositions({ positions }: { positions: unknown[] }) {
-    return <div data-testid="positions">Positions: {positions.length}</div>
-  }
-})
+const { getProjects, getPosts } = jest.requireMock<{
+  getProjects: jest.Mock
+  getPosts: jest.Mock
+}>('@/lib/contentful')
 
 jest.mock('@/components/MorePosts', () => {
   return function MockMorePosts({ posts }: { posts: unknown[] }) {
@@ -50,9 +17,9 @@ jest.mock('@/components/MorePosts', () => {
   }
 })
 
-jest.mock('@/components/Icon', () => {
-  return function MockIcon({ type }: { type: string }) {
-    return <span data-testid={`icon-${type}`}>{type}</span>
+jest.mock('@/components/MoreProjects', () => {
+  return function MockMoreProjects({ items }: { items: unknown[] }) {
+    return <div data-testid="more-projects">Projects: {items.length}</div>
   }
 })
 
@@ -62,23 +29,39 @@ jest.mock('@/components/LastSongWrapper', () => {
   }
 })
 
-jest.mock('lucide-react', () => ({
-  Play: () => <span data-testid="play-icon">Play</span>,
-  ExternalLink: () => (
-    <span data-testid="external-link-icon">ExternalLink</span>
-  ),
-  Music: () => <span data-testid="music-icon">Music</span>,
-}))
+jest.mock('@/components/HubDoors', () => {
+  return function MockHubDoors({
+    doors,
+  }: {
+    doors: { href: string; label: string }[]
+  }) {
+    return (
+      <nav data-testid="hub-doors" aria-label="Site sections">
+        {doors.map((d) => (
+          <a key={d.href} href={d.href}>
+            {d.label}
+          </a>
+        ))}
+      </nav>
+    )
+  }
+})
 
 jest.mock('next/link', () => {
   return function MockLink({
     children,
     href,
+    ...rest
   }: {
     children: React.ReactNode
     href: string
+    [key: string]: unknown
   }) {
-    return <a href={href}>{children}</a>
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    )
   }
 })
 
@@ -96,16 +79,13 @@ jest.mock('next/image', () => {
     style?: React.CSSProperties
     [key: string]: unknown
   }) {
-    // Filter out Next.js-specific props that aren't valid HTML attributes
     const htmlProps = { ...props }
     delete htmlProps.fill
     delete htmlProps.priority
-
-    // Using <img> in test mock is intentional - Next.js Image component is mocked
     // eslint-disable-next-line @next/next/no-img-element
     return (
       <img
-        src={src}
+        src={typeof src === 'string' ? src : ''}
         alt={alt}
         data-testid="next-image"
         style={style}
@@ -125,251 +105,97 @@ jest.mock('@/styles/common', () => ({
   StyledContainer: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="container">{children}</div>
   ),
-  StyledList: ({ children }: { children: React.ReactNode }) => (
-    <ul data-testid="list">{children}</ul>
-  ),
-  StyledListItem: ({ children }: { children: React.ReactNode }) => (
-    <li data-testid="list-item">{children}</li>
-  ),
   StyledSection: ({
     children,
     id,
+    'aria-label': ariaLabel,
   }: {
     children: React.ReactNode
     id?: string
+    'aria-label'?: string
   }) => (
-    <section data-testid="section" id={id}>
+    <section data-testid="section" id={id} aria-label={ariaLabel}>
       {children}
     </section>
   ),
   StyledImageContainer: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="image-container">{children}</div>
   ),
-  StyledLink: ({
-    children,
-    href,
-    ...props
-  }: {
-    children: React.ReactNode
-    href: string
-    [key: string]: unknown
-  }) => <a href={href} {...props}>{children}</a>,
 }))
 
-describe('Home Page', () => {
+const fakeProjects = [
+  { slug: 'p1', title: 'Project 1', order: 2, excerpt: 'e1' },
+  { slug: 'p2', title: 'Project 2', order: 1, excerpt: 'e2' },
+  { slug: 'p3', title: 'Project 3', order: 3, excerpt: 'e3' },
+  { slug: 'p4', title: 'Project 4', order: 4, excerpt: 'e4' },
+]
+
+const fakePosts = [
+  { slug: 'a', title: 'A', date: '2024-01-01' },
+  { slug: 'b', title: 'B', date: '2025-06-01' },
+  { slug: 'c', title: 'C', date: '2025-01-01' },
+  { slug: 'd', title: 'D', date: '2023-01-01' },
+]
+
+describe('Home page (hub)', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-
-    // Setup default mock data
-    getSkills.mockResolvedValue([
-      { name: 'React', level: 'Expert' },
-      { name: 'TypeScript', level: 'Expert' },
-    ])
-    getProjects.mockResolvedValue([
-      { slug: 'project-1', title: 'Project 1' },
-      { slug: 'project-2', title: 'Project 2' },
-    ])
-    getReferences.mockResolvedValue([
-      { citeName: 'John Doe', company: 'Acme Corp' },
-    ])
-    getPositions.mockResolvedValue([
-      { title: 'Senior Developer', company: 'Tech Corp' },
-    ])
-    getPosts.mockResolvedValue([
-      { slug: 'post-1', title: 'Post 1' },
-      { slug: 'post-2', title: 'Post 2' },
-    ])
+    getProjects.mockResolvedValue(fakeProjects)
+    getPosts.mockResolvedValue(fakePosts)
   })
 
-  it('should render main heading', async () => {
-    // Act
+  it('renders a single h1 with the role + title', async () => {
     const pageComponent = await Page()
     render(pageComponent)
 
-    // Assert
+    const headings = screen.getAllByRole('heading', { level: 1 })
+    expect(headings).toHaveLength(1)
+    expect(headings[0]).toHaveTextContent(/manager \/ full stack developer/i)
+  })
+
+  it('renders three door cards linking to /about, /projects, /posts', async () => {
+    const pageComponent = await Page()
+    render(pageComponent)
+
     expect(
-      screen.getByRole('heading', { name: /full stack developer/i })
-    ).toBeInTheDocument()
-  })
-
-  it('should render intro paragraph', async () => {
-    // Act
-    const pageComponent = await Page()
-    render(pageComponent)
-
-    // Assert
-    expect(screen.getByTestId('intro-paragraph')).toBeInTheDocument()
+      screen.getByRole('link', { name: /about/i })
+    ).toHaveAttribute('href', '/about')
     expect(
-      screen.getByText(/hi! i'm an ai-first application development manager/i)
-    ).toBeInTheDocument()
-  })
-
-  it('should render contact list', async () => {
-    // Act
-    const pageComponent = await Page()
-    render(pageComponent)
-
-    // Assert
-    expect(screen.getByTestId('contact-list')).toBeInTheDocument()
-  })
-
-  it('should render skills section', async () => {
-    // Act
-    const pageComponent = await Page()
-    render(pageComponent)
-
-    // Assert
-    expect(screen.getByRole('heading', { name: /skills/i })).toBeInTheDocument()
-    expect(screen.getByTestId('skills')).toBeInTheDocument()
-    expect(screen.getByText(/skills: 2/i)).toBeInTheDocument()
-  })
-
-  it('should render experience section with positions', async () => {
-    // Act
-    const pageComponent = await Page()
-    render(pageComponent)
-
-    // Assert
-    expect(
-      screen.getByRole('heading', { name: /experience/i })
-    ).toBeInTheDocument()
-    expect(screen.getByTestId('positions')).toBeInTheDocument()
-    expect(screen.getByText(/positions: 1/i)).toBeInTheDocument()
-  })
-
-  it('should render LinkedIn link in experience section', async () => {
-    // Act
-    const pageComponent = await Page()
-    render(pageComponent)
-
-    // Assert
-    const linkedInLink = screen.getByRole('link', {
-      name: /see more on linkedin/i,
-    })
-    expect(linkedInLink).toBeInTheDocument()
-    expect(linkedInLink).toHaveAttribute(
+      screen.getByRole('link', { name: /projects/i })
+    ).toHaveAttribute('href', '/projects')
+    expect(screen.getByRole('link', { name: /blog/i })).toHaveAttribute(
       'href',
-      'https://www.linkedin.com/in/jasonrundell/'
+      '/posts'
     )
-    // Verify ExternalLink icon is present
-    expect(screen.getByTestId('external-link-icon')).toBeInTheDocument()
   })
 
-  it('should render projects section', async () => {
-    // Act
+  it('renders the LastSong card', async () => {
     const pageComponent = await Page()
     render(pageComponent)
 
-    // Assert
-    expect(
-      screen.getByRole('heading', { name: /projects/i })
-    ).toBeInTheDocument()
-    const projectLinks = screen.getAllByRole('link')
-    const project1Link = projectLinks.find(
-      (link) => link.getAttribute('href') === '/projects/project-1'
+    expect(screen.getByTestId('last-song-wrapper')).toBeInTheDocument()
+  })
+
+  it('limits selected projects to three (sorted by order)', async () => {
+    const pageComponent = await Page()
+    render(pageComponent)
+
+    expect(screen.getByTestId('more-projects')).toHaveTextContent(
+      'Projects: 3'
     )
-    expect(project1Link).toBeInTheDocument()
-    expect(project1Link).toHaveTextContent('Project 1')
   })
 
-  it('should render recommendations section with references', async () => {
-    // Act
+  it('limits latest posts to three (sorted by date desc)', async () => {
     const pageComponent = await Page()
     render(pageComponent)
 
-    // Assert
-    expect(
-      screen.getByRole('heading', { name: /recommendations/i })
-    ).toBeInTheDocument()
-    expect(screen.getByTestId('references')).toBeInTheDocument()
-    expect(screen.getByText(/references: 1/i)).toBeInTheDocument()
+    expect(screen.getByTestId('more-posts')).toHaveTextContent('Posts: 3')
   })
 
-  it('should render blog section with posts', async () => {
-    // Act
-    const pageComponent = await Page()
-    render(pageComponent)
-
-    // Assert
-    expect(screen.getByRole('heading', { name: /blog/i })).toBeInTheDocument()
-    expect(screen.getByTestId('more-posts')).toBeInTheDocument()
-    expect(screen.getByText(/posts: 2/i)).toBeInTheDocument()
-  })
-
-  it('should fetch all data in parallel', async () => {
-    // Act
+  it('fetches projects and posts in parallel', async () => {
     await Page()
 
-    // Assert
-    expect(getSkills).toHaveBeenCalled()
     expect(getProjects).toHaveBeenCalled()
-    expect(getReferences).toHaveBeenCalled()
-    expect(getPositions).toHaveBeenCalled()
     expect(getPosts).toHaveBeenCalled()
-
-    // All should be called (parallel execution)
-    const allCalls = [
-      getSkills.mock.invocationCallOrder[0],
-      getProjects.mock.invocationCallOrder[0],
-      getReferences.mock.invocationCallOrder[0],
-      getPositions.mock.invocationCallOrder[0],
-      getPosts.mock.invocationCallOrder[0],
-    ]
-    // They should all be called around the same time (within same tick)
-    const maxCallOrder = Math.max(...allCalls)
-    const minCallOrder = Math.min(...allCalls)
-    // All calls should be very close together (within 5 calls)
-    expect(maxCallOrder - minCallOrder).toBeLessThan(5)
-  })
-
-  it('should handle empty data gracefully', async () => {
-    // Arrange
-    getSkills.mockResolvedValue([])
-    getProjects.mockResolvedValue([])
-    getReferences.mockResolvedValue([])
-    getPositions.mockResolvedValue([])
-    getPosts.mockResolvedValue([])
-
-    // Act
-    const pageComponent = await Page()
-    render(pageComponent)
-
-    // Assert
-    // When data is empty, components may not render, so check what's actually rendered
-    const skillsElement = screen.queryByTestId('skills')
-    if (skillsElement) {
-      expect(skillsElement).toHaveTextContent(/skills: 0/i)
-    }
-    // Positions component may not render with empty array
-    const positionsElement = screen.queryByTestId('positions')
-    if (positionsElement) {
-      expect(positionsElement).toHaveTextContent(/positions: 0/i)
-    }
-    const referencesElement = screen.queryByTestId('references')
-    if (referencesElement) {
-      expect(referencesElement).toHaveTextContent(/references: 0/i)
-    }
-    const postsElement = screen.queryByTestId('more-posts')
-    if (postsElement) {
-      expect(postsElement).toHaveTextContent(/posts: 0/i)
-    }
-  })
-
-  it('should have correct section IDs for navigation', async () => {
-    // Act
-    const pageComponent = await Page()
-    render(pageComponent)
-
-    // Assert
-    const sections = screen.getAllByTestId('section')
-    const sectionIds = sections
-      .map((section) => section.getAttribute('id'))
-      .filter(Boolean)
-    expect(sectionIds).toContain('home')
-    expect(sectionIds).toContain('skills')
-    expect(sectionIds).toContain('experience')
-    expect(sectionIds).toContain('projects')
-    expect(sectionIds).toContain('recommendations')
-    expect(sectionIds).toContain('blog')
   })
 })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,64 +1,109 @@
 import React from 'react'
-import { ExternalLink } from 'lucide-react'
 import Image from 'next/image'
 import dynamic from 'next/dynamic'
-import { Row, Grid, Spacer } from '@jasonrundell/dropship'
+import { Row, Spacer, Grid } from '@jasonrundell/dropship'
 
-import {
-  getSkills,
-  getProjects,
-  getReferences,
-  getPositions,
-  getPosts,
-} from '@/lib/contentful'
+import { getProjects, getPosts } from '@/lib/contentful'
+import { Project } from '@/typeDefinitions/app'
 
 import {
   StyledDivBgDark,
   StyledIntroParagraph,
   StyledContainer,
-  StyledList,
-  StyledListItem,
   StyledSection,
   StyledImageContainer,
-  StyledLink,
 } from '@/styles/common'
 
-import Skills from '@/components/Skills'
-import ContactList from '@/components/ContactList'
-import References from '@/components/References'
-import Positions from '@/components/Positions'
 import MorePosts from '@/components/MorePosts'
-import Icon from '@/components/Icon'
+import MoreProjects from '@/components/MoreProjects'
+import HubDoors, { HubDoor } from '@/components/HubDoors'
 import HeroImage from '@/public/images/ai-powered-developer.webp'
 
-// Lazy-load LastSongWrapper to reduce initial bundle size (below the fold)
 const LastSongWrapper = dynamic(() => import('@/components/LastSongWrapper'), {
   loading: () => <div>Loading...</div>,
 })
 
-// Image style constants
 const imageCoverStyle: React.CSSProperties = {
   objectFit: 'cover',
   objectPosition: 'center',
 }
 
-/**
- * Home page component that displays skills, projects, experience, references, and blog posts.
- * Fetches data from Contentful in parallel for optimal performance.
- */
+const HUB_DOORS: ReadonlyArray<HubDoor> = [
+  {
+    href: '/about',
+    label: 'About',
+    description: 'Bio, skills, experience, and recommendations.',
+  },
+  {
+    href: '/projects',
+    label: 'Projects',
+    description: 'A complete index of shipped and side projects.',
+  },
+  {
+    href: '/posts',
+    label: 'Blog',
+    description: 'Notes on the web, engineering, and AI-assisted work.',
+  },
+] as const
 
-// Revalidate every day (ISR - Incremental Static Regeneration)
+const HOMEPAGE_PROJECT_LIMIT = 3
+const HOMEPAGE_POST_LIMIT = 3
+
+type ProjectCardItem = {
+  title: string
+  featuredImage: {
+    file: { url: string }
+    altText: string
+    description: string
+  }
+  excerpt: string
+  slug: string
+}
+
+function toProjectCardItem(project: Project): ProjectCardItem {
+  const fields = project.featuredImage?.fields
+  const file = fields?.file?.fields?.file
+
+  return {
+    title: project.title,
+    excerpt: project.excerpt,
+    slug: project.slug,
+    featuredImage: {
+      file: { url: file?.url ?? '' },
+      altText: fields?.altText ?? '',
+      description: fields?.description ?? '',
+    },
+  }
+}
+
+export const metadata = {
+  title: 'Manager / Full Stack Developer | Jason Rundell',
+  description:
+    'Jason Rundell — AI-first Application Development Manager and Senior Full Stack Web Developer.',
+}
+
 export const revalidate = 86400
 
-export default async function page() {
-  // Parallelize Contentful queries for better performance
-  const [skills, projects, references, positions, posts] = await Promise.all([
-    getSkills(),
-    getProjects(),
-    getReferences(),
-    getPositions(),
-    getPosts(),
-  ])
+export default async function HomePage() {
+  const [projects, posts] = await Promise.all([getProjects(), getPosts()])
+
+  const selectedProjects = [...projects]
+    .sort((a, b) => {
+      const orderA =
+        typeof a.order === 'number' ? a.order : Number.MAX_SAFE_INTEGER
+      const orderB =
+        typeof b.order === 'number' ? b.order : Number.MAX_SAFE_INTEGER
+      return orderA - orderB
+    })
+    .slice(0, HOMEPAGE_PROJECT_LIMIT)
+
+  const latestPosts = [...posts]
+    .sort((a, b) => {
+      const dateA = a.date ? new Date(a.date).getTime() : 0
+      const dateB = b.date ? new Date(b.date).getTime() : 0
+      return dateB - dateA
+    })
+    .slice(0, HOMEPAGE_POST_LIMIT)
 
   return (
     <>
@@ -77,103 +122,49 @@ export default async function page() {
             />
           </StyledImageContainer>
           <Spacer />
-          <Row>
-            <StyledIntroParagraph>
-              Hi! I&apos;m an AI-first Application Development Manager and
-              Senior Full Stack Web Developer with 20+ years leading high-impact
-              web platforms and engineering teams. Skilled at modernizing legacy
-              systems into scalable web applications, integrating AI into
-              workflows and products, and aligning delivery with business goals.
-            </StyledIntroParagraph>
-            <p>
-              My passion for creating web experiences began in my high
-              school&apos;s library back in 1997 when I discovered GeoCities.
-              Since then, I&apos;ve been fortunate to work on a diverse range of
-              projects spanning multiple technologies, including iframes, Flash,
-              WordPress multisites, jQuery Mobile, custom CMS applications, a
-              Facebook contest platform, React design systems, Jamstack
-              architecture, and most recently, exploration of the possibilities
-              and limitations of automation, and AI.
-            </p>
-            <p>
-              I&apos;m constantly exploring new trends and experimenting with
-              emerging technologies in my spare time to expand my skills and
-              knowledge. As a lifelong learner, I embrace change, seek out
-              challenges, and thrive on the fast-paced nature of the tech
-              industry. After 20 years, I still love working on the web!
-            </p>
-          </Row>
           <Grid
             gridTemplateColumns="1fr"
-            largeTemplateColumns="1fr 1fr"
+            largeTemplateColumns="2fr 1fr"
             columnGap="2rem"
           >
-            <ContactList />
-            <LastSongWrapper />
+            <Row>
+              <StyledIntroParagraph>
+                Hi! I&apos;m an AI-first Application Development Manager and
+                Senior Full Stack Web Developer with 20+ years leading
+                high-impact web platforms and engineering teams.
+              </StyledIntroParagraph>
+              <p>
+                Looking for the long version, my work, or my writing? Pick a
+                door.
+              </p>
+            </Row>
+            <Row>
+              <LastSongWrapper />
+            </Row>
           </Grid>
         </StyledSection>
 
-        <Grid columnGap="2rem">
-          <StyledSection id="skills">
-            <h2>Skills</h2>
-            <Row>{skills && <Skills skills={skills} />}</Row>
-          </StyledSection>
-          <StyledSection id="experience">
-            <h2>Experience</h2>
-            <Row>
-              {positions.length > 0 && <Positions positions={positions} />}
-            </Row>
-            <Row>
-              <StyledList>
-                <StyledListItem>
-                  <Icon type="LinkedIn" />{' '}
-                  <StyledLink
-                    href="https://www.linkedin.com/in/jasonrundell/"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                    aria-label="See more on LinkedIn"
-                  >
-                    <ExternalLink size={18} /> See more on LinkedIn
-                  </StyledLink>
-                </StyledListItem>
-              </StyledList>
-            </Row>
-          </StyledSection>
-          <StyledSection id="projects">
-            <h2>Projects</h2>
-            <Row>
-              <StyledList>
-                {projects.length > 0 &&
-                  projects.map((project) => (
-                    <StyledListItem key={project.slug}>
-                      <Icon type="GitHub" />{' '}
-                      <StyledLink
-                        href={`/projects/${project.slug}`}
-                        aria-label={project.title}
-                      >
-                        {project.title}
-                      </StyledLink>
-                    </StyledListItem>
-                  ))}
-              </StyledList>
-            </Row>
-          </StyledSection>
-        </Grid>
-        <StyledSection id="recommendations">
-          <h2>Recommendations</h2>
+        <StyledSection id="doors">
+          <HubDoors doors={HUB_DOORS} />
+        </StyledSection>
+
+        <StyledSection id="selected-projects">
+          <h2>Selected projects</h2>
           <Row>
-            {references.length > 0 && <References references={references} />}
+            <MoreProjects items={selectedProjects.map(toProjectCardItem)} />
           </Row>
         </StyledSection>
       </StyledContainer>
 
       <StyledDivBgDark>
         <StyledContainer>
-          <StyledSection id="blog">
+          <StyledSection id="latest-posts">
             <Spacer />
-            <h2>Blog</h2>
+            <h2>Latest posts</h2>
             <Spacer />
-            <Row>{posts.length > 0 && <MorePosts posts={posts} />}</Row>
+            <Row>
+              <MorePosts posts={latestPosts} />
+            </Row>
           </StyledSection>
         </StyledContainer>
       </StyledDivBgDark>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic'
 import { Row, Spacer, Grid } from '@jasonrundell/dropship'
 
 import { getProjects, getPosts } from '@/lib/contentful'
-import { Project } from '@/typeDefinitions/app'
+import { toProjectCardItem } from '@/lib/projectUtils'
 
 import {
   StyledDivBgDark,
@@ -48,33 +48,6 @@ const HUB_DOORS: ReadonlyArray<HubDoor> = [
 
 const HOMEPAGE_PROJECT_LIMIT = 3
 const HOMEPAGE_POST_LIMIT = 3
-
-type ProjectCardItem = {
-  title: string
-  featuredImage: {
-    file: { url: string }
-    altText: string
-    description: string
-  }
-  excerpt: string
-  slug: string
-}
-
-function toProjectCardItem(project: Project): ProjectCardItem {
-  const fields = project.featuredImage?.fields
-  const file = fields?.file?.fields?.file
-
-  return {
-    title: project.title,
-    excerpt: project.excerpt,
-    slug: project.slug,
-    featuredImage: {
-      file: { url: file?.url ?? '' },
-      altText: fields?.altText ?? '',
-      description: fields?.description ?? '',
-    },
-  }
-}
 
 export const metadata = {
   title: 'Manager / Full Stack Developer | Jason Rundell',

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { sanitizeHTML } from '@/lib/sanitize'
 import { getEntryBySlug, getPosts } from '@/lib/contentful'
 import PostHeader from '@/components/PostHeader'
 import { SITE_DESCRIPTION } from '@/lib/constants'
+import { buildBlogPostingJsonLd } from '@/lib/jsonld'
 import { Post } from '@/typeDefinitions/app'
 import {
   StyledContainer,
@@ -76,12 +77,20 @@ export default async function page({ params }: PostProps) {
     notFound()
   }
 
+  const blogPostingJsonLd = buildBlogPostingJsonLd(post as Post, slug)
+
   return (
     <>
       <StyledContainer>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(blogPostingJsonLd),
+          }}
+        />
         <StyledSection id="home">
           <StyledBreadcrumb>
-            <Link href={`/`}>Home</Link> &gt; <Link href={`/#blog`}>Blog</Link>{' '}
+            <Link href={`/`}>Home</Link> &gt; <Link href={`/posts`}>Blog</Link>{' '}
           </StyledBreadcrumb>
           <article>
             <PostHeader post={post as Post} />

--- a/src/app/posts/page.test.tsx
+++ b/src/app/posts/page.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react'
+import PostsPage from './page'
+
+jest.mock('@/lib/contentful', () => ({
+  getPosts: jest.fn(),
+}))
+
+const { getPosts } = jest.requireMock<{
+  getPosts: jest.Mock
+}>('@/lib/contentful')
+
+jest.mock('@/components/MorePosts', () => {
+  return function MockMorePosts({
+    posts,
+  }: {
+    posts: { slug: string; title: string }[]
+  }) {
+    return (
+      <div data-testid="more-posts">
+        {posts.map((p) => (
+          <span key={p.slug} data-testid="post-item">
+            {p.title}
+          </span>
+        ))}
+      </div>
+    )
+  }
+})
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) {
+    return <a href={href}>{children}</a>
+  }
+})
+
+jest.mock('@/styles/common', () => ({
+  StyledContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="container">{children}</div>
+  ),
+  StyledSection: ({
+    children,
+    id,
+  }: {
+    children: React.ReactNode
+    id?: string
+  }) => (
+    <section data-testid="section" id={id}>
+      {children}
+    </section>
+  ),
+  StyledBreadcrumb: ({ children }: { children: React.ReactNode }) => (
+    <nav data-testid="breadcrumb" aria-label="Breadcrumb">
+      {children}
+    </nav>
+  ),
+}))
+
+describe('Posts page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getPosts.mockResolvedValue([
+      { slug: 'old', title: 'Old', date: '2023-01-01' },
+      { slug: 'new', title: 'New', date: '2025-06-01' },
+      { slug: 'mid', title: 'Mid', date: '2024-06-01' },
+    ])
+  })
+
+  it('renders a single h1 with the Blog title', async () => {
+    const pageComponent = await PostsPage()
+    render(pageComponent)
+
+    const headings = screen.getAllByRole('heading', { level: 1 })
+    expect(headings).toHaveLength(1)
+    expect(headings[0]).toHaveTextContent(/^blog$/i)
+  })
+
+  it('renders posts sorted by date descending', async () => {
+    const pageComponent = await PostsPage()
+    render(pageComponent)
+
+    const items = screen.getAllByTestId('post-item')
+    expect(items.map((el) => el.textContent)).toEqual(['New', 'Mid', 'Old'])
+  })
+})

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import Link from 'next/link'
+import { Row, Spacer } from '@jasonrundell/dropship'
+
+import { getPosts } from '@/lib/contentful'
+import {
+  StyledContainer,
+  StyledSection,
+  StyledBreadcrumb,
+} from '@/styles/common'
+import MorePosts from '@/components/MorePosts'
+
+export const metadata = {
+  title: 'Blog | Jason Rundell',
+  description:
+    'The full blog archive by Jason Rundell — notes on the web, engineering, AI, and the craft of shipping.',
+}
+
+export const revalidate = 86400
+
+export default async function PostsPage() {
+  const posts = await getPosts()
+
+  const sortedPosts = [...posts].sort((a, b) => {
+    const dateA = a.date ? new Date(a.date).getTime() : 0
+    const dateB = b.date ? new Date(b.date).getTime() : 0
+    return dateB - dateA
+  })
+
+  return (
+    <StyledContainer>
+      <StyledSection id="posts">
+        <StyledBreadcrumb>
+          <Link href="/">Home</Link> &gt; Blog
+        </StyledBreadcrumb>
+        <h1>Blog</h1>
+        <Row>
+          <p>
+            Notes, tutorials, and longer thoughts on building for the web, the
+            engineering craft, and the practical edges of AI-assisted work.
+          </p>
+        </Row>
+        <Spacer />
+        <Row>
+          <MorePosts posts={sortedPosts} />
+        </Row>
+      </StyledSection>
+    </StyledContainer>
+  )
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -147,7 +147,7 @@ export default async function page({ params }: ProjectProps) {
       <StyledContainer>
         <StyledBreadcrumb>
           <Link href={`/`}>Home</Link> &gt;{' '}
-          <Link href={`/#projects`}>Projects</Link> &gt; {title}
+          <Link href={`/projects`}>Projects</Link> &gt; {title}
         </StyledBreadcrumb>
         <StyledSection id="project">
           <article>

--- a/src/app/projects/page.test.tsx
+++ b/src/app/projects/page.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react'
+import ProjectsPage from './page'
+
+jest.mock('@/lib/contentful', () => ({
+  getProjects: jest.fn(),
+}))
+
+const { getProjects } = jest.requireMock<{
+  getProjects: jest.Mock
+}>('@/lib/contentful')
+
+jest.mock('@/components/MoreProjects', () => {
+  return function MockMoreProjects({
+    items,
+  }: {
+    items: { slug: string; title: string }[]
+  }) {
+    return (
+      <div data-testid="more-projects">
+        {items.map((item) => (
+          <span key={item.slug} data-testid="project-item">
+            {item.title}
+          </span>
+        ))}
+      </div>
+    )
+  }
+})
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) {
+    return <a href={href}>{children}</a>
+  }
+})
+
+jest.mock('@/styles/common', () => ({
+  StyledContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="container">{children}</div>
+  ),
+  StyledSection: ({
+    children,
+    id,
+  }: {
+    children: React.ReactNode
+    id?: string
+  }) => (
+    <section data-testid="section" id={id}>
+      {children}
+    </section>
+  ),
+  StyledBreadcrumb: ({ children }: { children: React.ReactNode }) => (
+    <nav data-testid="breadcrumb" aria-label="Breadcrumb">
+      {children}
+    </nav>
+  ),
+}))
+
+describe('Projects page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getProjects.mockResolvedValue([
+      { slug: 'b', title: 'B', order: 2, excerpt: 'eb' },
+      { slug: 'a', title: 'A', order: 1, excerpt: 'ea' },
+      { slug: 'c', title: 'C', order: 3, excerpt: 'ec' },
+    ])
+  })
+
+  it('renders a single h1 with the page title', async () => {
+    const pageComponent = await ProjectsPage()
+    render(pageComponent)
+
+    const headings = screen.getAllByRole('heading', { level: 1 })
+    expect(headings).toHaveLength(1)
+    expect(headings[0]).toHaveTextContent(/^projects$/i)
+  })
+
+  it('renders all projects sorted by order', async () => {
+    const pageComponent = await ProjectsPage()
+    render(pageComponent)
+
+    const items = screen.getAllByTestId('project-item')
+    expect(items.map((el) => el.textContent)).toEqual(['A', 'B', 'C'])
+  })
+
+  it('renders a breadcrumb to home', async () => {
+    const pageComponent = await ProjectsPage()
+    render(pageComponent)
+
+    expect(screen.getByTestId('breadcrumb')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /^home$/i })).toHaveAttribute(
+      'href',
+      '/'
+    )
+  })
+})

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { Row, Spacer } from '@jasonrundell/dropship'
 
 import { getProjects } from '@/lib/contentful'
-import { Project } from '@/typeDefinitions/app'
+import { toProjectCardItem } from '@/lib/projectUtils'
 import {
   StyledContainer,
   StyledSection,
@@ -18,33 +18,6 @@ export const metadata = {
 }
 
 export const revalidate = 86400
-
-type ProjectCardItem = {
-  title: string
-  featuredImage: {
-    file: { url: string }
-    altText: string
-    description: string
-  }
-  excerpt: string
-  slug: string
-}
-
-function toCardItem(project: Project): ProjectCardItem {
-  const fields = project.featuredImage?.fields
-  const file = fields?.file?.fields?.file
-
-  return {
-    title: project.title,
-    excerpt: project.excerpt,
-    slug: project.slug,
-    featuredImage: {
-      file: { url: file?.url ?? '' },
-      altText: fields?.altText ?? '',
-      description: fields?.description ?? '',
-    },
-  }
-}
 
 export default async function ProjectsPage() {
   const projects = await getProjects()
@@ -70,7 +43,7 @@ export default async function ProjectsPage() {
         </Row>
         <Spacer />
         <Row>
-          <MoreProjects items={sortedProjects.map(toCardItem)} />
+          <MoreProjects items={sortedProjects.map(toProjectCardItem)} />
         </Row>
       </StyledSection>
     </StyledContainer>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import Link from 'next/link'
+import { Row, Spacer } from '@jasonrundell/dropship'
+
+import { getProjects } from '@/lib/contentful'
+import { Project } from '@/typeDefinitions/app'
+import {
+  StyledContainer,
+  StyledSection,
+  StyledBreadcrumb,
+} from '@/styles/common'
+import MoreProjects from '@/components/MoreProjects'
+
+export const metadata = {
+  title: 'Projects | Jason Rundell',
+  description:
+    'A complete index of projects by Jason Rundell — open-source work, side projects, and shipped products.',
+}
+
+export const revalidate = 86400
+
+type ProjectCardItem = {
+  title: string
+  featuredImage: {
+    file: { url: string }
+    altText: string
+    description: string
+  }
+  excerpt: string
+  slug: string
+}
+
+function toCardItem(project: Project): ProjectCardItem {
+  const fields = project.featuredImage?.fields
+  const file = fields?.file?.fields?.file
+
+  return {
+    title: project.title,
+    excerpt: project.excerpt,
+    slug: project.slug,
+    featuredImage: {
+      file: { url: file?.url ?? '' },
+      altText: fields?.altText ?? '',
+      description: fields?.description ?? '',
+    },
+  }
+}
+
+export default async function ProjectsPage() {
+  const projects = await getProjects()
+
+  const sortedProjects = [...projects].sort((a, b) => {
+    const orderA = typeof a.order === 'number' ? a.order : Number.MAX_SAFE_INTEGER
+    const orderB = typeof b.order === 'number' ? b.order : Number.MAX_SAFE_INTEGER
+    return orderA - orderB
+  })
+
+  return (
+    <StyledContainer>
+      <StyledSection id="projects">
+        <StyledBreadcrumb>
+          <Link href="/">Home</Link> &gt; Projects
+        </StyledBreadcrumb>
+        <h1>Projects</h1>
+        <Row>
+          <p>
+            A full index of the projects I&apos;ve shipped, contributed to, or
+            built for fun. Pick one to see the tech stack and a short write-up.
+          </p>
+        </Row>
+        <Spacer />
+        <Row>
+          <MoreProjects items={sortedProjects.map(toCardItem)} />
+        </Row>
+      </StyledSection>
+    </StyledContainer>
+  )
+}

--- a/src/components/HubDoors.test.tsx
+++ b/src/components/HubDoors.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react'
+import HubDoors, { HubDoor } from './HubDoors'
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) {
+    return <a href={href}>{children}</a>
+  }
+})
+
+const fakeDoors: ReadonlyArray<HubDoor> = [
+  { href: '/about', label: 'About', description: 'about d' },
+  { href: '/projects', label: 'Projects', description: 'projects d' },
+  { href: '/posts', label: 'Blog', description: 'posts d' },
+]
+
+describe('HubDoors', () => {
+  it('renders one nav landmark labelled "Site sections" by default', () => {
+    render(<HubDoors doors={fakeDoors} />)
+
+    expect(
+      screen.getByRole('navigation', { name: /site sections/i })
+    ).toBeInTheDocument()
+  })
+
+  it('honors a custom aria-label', () => {
+    render(<HubDoors doors={fakeDoors} ariaLabel="Choose a destination" />)
+
+    expect(
+      screen.getByRole('navigation', { name: /choose a destination/i })
+    ).toBeInTheDocument()
+  })
+
+  it('renders one link per door with the right href and label', () => {
+    render(<HubDoors doors={fakeDoors} />)
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(3)
+
+    expect(screen.getByRole('link', { name: /about/i })).toHaveAttribute(
+      'href',
+      '/about'
+    )
+    expect(screen.getByRole('link', { name: /projects/i })).toHaveAttribute(
+      'href',
+      '/projects'
+    )
+    expect(screen.getByRole('link', { name: /blog/i })).toHaveAttribute(
+      'href',
+      '/posts'
+    )
+  })
+
+  it('renders the description text inside each door', () => {
+    render(<HubDoors doors={fakeDoors} />)
+
+    expect(screen.getByText(/about d/i)).toBeInTheDocument()
+    expect(screen.getByText(/projects d/i)).toBeInTheDocument()
+    expect(screen.getByText(/posts d/i)).toBeInTheDocument()
+  })
+
+  it('renders an empty nav when given no doors', () => {
+    render(<HubDoors doors={[]} />)
+
+    const nav = screen.getByRole('navigation', { name: /site sections/i })
+    expect(nav).toBeInTheDocument()
+    expect(screen.queryAllByRole('link')).toHaveLength(0)
+  })
+})

--- a/src/components/HubDoors.tsx
+++ b/src/components/HubDoors.tsx
@@ -1,0 +1,94 @@
+import Link from 'next/link'
+import { styled } from '@pigment-css/react'
+
+import Tokens from '@/lib/tokens'
+
+export type HubDoor = {
+  href: string
+  label: string
+  description: string
+}
+
+interface HubDoorsProps {
+  doors: ReadonlyArray<HubDoor>
+  ariaLabel?: string
+}
+
+const StyledDoorsGrid = styled('nav')`
+  display: grid;
+  gap: ${Tokens.sizes.large.value}${Tokens.sizes.large.unit};
+  grid-template-columns: 1fr;
+  margin: 0;
+  padding: 0;
+
+  @media (min-width: ${Tokens.sizes.breakpoints.medium.value}${Tokens.sizes
+      .breakpoints.medium.unit}) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+`
+
+const StyledDoorList = styled('ul')`
+  display: contents;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`
+
+const StyledDoorItem = styled('li')`
+  margin: 0;
+  padding: 0;
+`
+
+const StyledDoor = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  gap: ${Tokens.sizes.small.value}${Tokens.sizes.small.unit};
+  padding: ${Tokens.sizes.large.value}${Tokens.sizes.large.unit};
+  border: 1px solid ${Tokens.colors.surfaceDeepest.var};
+  background: ${Tokens.colors.surfaceElevated.var};
+  color: ${Tokens.colors.roleHeading.var};
+  text-decoration: none;
+  border-radius: ${Tokens.borderRadius.medium.value}${Tokens.borderRadius
+      .medium.unit};
+  transition: border-color 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    border-color: ${Tokens.colors.rolePrompt.var};
+  }
+`
+
+const StyledDoorLabel = styled('span')`
+  font-weight: 700;
+  font-size: ${Tokens.sizes.medium.value}${Tokens.sizes.medium.unit};
+`
+
+const StyledDoorDescription = styled('span')`
+  font-size: ${Tokens.sizes.fonts.small.value}${Tokens.sizes.fonts.small.unit};
+  color: ${Tokens.colors.roleBody.var};
+`
+
+/**
+ * Hub doors — a small navigation grid of CTA cards that sends visitors to the
+ * site's main sub-pages. Phase 4 will restyle these as terminal-style buttons;
+ * keeping the markup behind a single component preserves a stable interface.
+ */
+export default function HubDoors({
+  doors,
+  ariaLabel = 'Site sections',
+}: HubDoorsProps) {
+  return (
+    <StyledDoorsGrid aria-label={ariaLabel}>
+      <StyledDoorList>
+        {doors.map((door) => (
+          <StyledDoorItem key={door.href}>
+            <StyledDoor href={door.href}>
+              <StyledDoorLabel>{door.label}</StyledDoorLabel>
+              <StyledDoorDescription>{door.description}</StyledDoorDescription>
+            </StyledDoor>
+          </StyledDoorItem>
+        ))}
+      </StyledDoorList>
+    </StyledDoorsGrid>
+  )
+}

--- a/src/components/MainNav.test.tsx
+++ b/src/components/MainNav.test.tsx
@@ -65,24 +65,36 @@ describe('MainNav Component', () => {
     expect(animations.length).toBeGreaterThan(0)
   })
 
-  it('should render Blog link in desktop navigation', () => {
-    // Act
+  it('should render About link in desktop navigation', () => {
     render(<MainNav />)
 
-    // Assert
-    const blogLink = screen.getByRole('link', { name: /blog/i })
-    expect(blogLink).toBeInTheDocument()
-    expect(blogLink).toHaveAttribute('href', '/#blog')
+    const aboutLink = screen.getByRole('link', { name: /^about$/i })
+    expect(aboutLink).toBeInTheDocument()
+    expect(aboutLink).toHaveAttribute('href', '/about')
   })
 
   it('should render Projects link in desktop navigation', () => {
-    // Act
     render(<MainNav />)
 
-    // Assert
-    const projectsLink = screen.getByRole('link', { name: /projects/i })
+    const projectsLink = screen.getByRole('link', { name: /^projects$/i })
     expect(projectsLink).toBeInTheDocument()
-    expect(projectsLink).toHaveAttribute('href', '/#projects')
+    expect(projectsLink).toHaveAttribute('href', '/projects')
+  })
+
+  it('should render Blog link in desktop navigation', () => {
+    render(<MainNav />)
+
+    const blogLink = screen.getByRole('link', { name: /^blog$/i })
+    expect(blogLink).toBeInTheDocument()
+    expect(blogLink).toHaveAttribute('href', '/posts')
+  })
+
+  it('should render Contact link in desktop navigation', () => {
+    render(<MainNav />)
+
+    const contactLink = screen.getByRole('link', { name: /^contact$/i })
+    expect(contactLink).toBeInTheDocument()
+    expect(contactLink).toHaveAttribute('href', '/contact')
   })
 
   it('should render MainNavClient component', () => {

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -191,10 +191,16 @@ export default function MainNav() {
               <StyledTitle steps={NAVIGATION_STEPS} speed={100} />
             </StyledListItem>
             <StyledListItem>
-              <Link href="/#blog">Blog</Link>
+              <Link href="/about">About</Link>
             </StyledListItem>
             <StyledListItem>
-              <Link href="/#projects">Projects</Link>
+              <Link href="/projects">Projects</Link>
+            </StyledListItem>
+            <StyledListItem>
+              <Link href="/posts">Blog</Link>
+            </StyledListItem>
+            <StyledListItem>
+              <Link href="/contact">Contact</Link>
             </StyledListItem>
           </StyledList>
         </StyledDesktopNav>

--- a/src/components/MainNavClient.tsx
+++ b/src/components/MainNavClient.tsx
@@ -275,13 +275,23 @@ const MainNavClient: React.FC<MainNavClientProps> = () => {
       >
         <StyledMobileList>
           <StyledMobileListItem>
-            <Link href="/#blog" onClick={closeMobileMenu}>
+            <Link href="/about" onClick={closeMobileMenu}>
+              About
+            </Link>
+          </StyledMobileListItem>
+          <StyledMobileListItem>
+            <Link href="/projects" onClick={closeMobileMenu}>
+              Projects
+            </Link>
+          </StyledMobileListItem>
+          <StyledMobileListItem>
+            <Link href="/posts" onClick={closeMobileMenu}>
               Blog
             </Link>
           </StyledMobileListItem>
           <StyledMobileListItem>
-            <Link href="/#projects" onClick={closeMobileMenu}>
-              Projects
+            <Link href="/contact" onClick={closeMobileMenu}>
+              Contact
             </Link>
           </StyledMobileListItem>
           {user ? (

--- a/src/lib/jsonld.test.ts
+++ b/src/lib/jsonld.test.ts
@@ -1,0 +1,105 @@
+import { buildPersonJsonLd, buildBlogPostingJsonLd } from './jsonld'
+import type { Post } from '@/typeDefinitions/app'
+import { SITE_DOMAIN } from '@/lib/constants'
+
+describe('buildPersonJsonLd', () => {
+  it('returns a schema.org Person with the expected identity', () => {
+    const ld = buildPersonJsonLd()
+
+    expect(ld['@context']).toBe('https://schema.org')
+    expect(ld['@type']).toBe('Person')
+    expect(ld.name).toBe('Jason Rundell')
+    expect(ld.url).toBe(`${SITE_DOMAIN}/about`)
+    expect(ld.sameAs).toEqual(
+      expect.arrayContaining([
+        'https://www.linkedin.com/in/jasonrundell/',
+        'https://github.com/jasonrundell',
+      ])
+    )
+  })
+})
+
+describe('buildBlogPostingJsonLd', () => {
+  const basePost = {
+    title: 'Hello world',
+    slug: 'hello-world',
+    excerpt: 'A short excerpt',
+    date: '2025-04-01',
+  } as unknown as Post
+
+  it('returns a BlogPosting with the canonical url', () => {
+    const ld = buildBlogPostingJsonLd(basePost, 'hello-world')
+
+    expect(ld['@type']).toBe('BlogPosting')
+    expect(ld.headline).toBe('Hello world')
+    expect(ld.description).toBe('A short excerpt')
+    expect(ld.datePublished).toBe('2025-04-01')
+    expect(ld.mainEntityOfPage).toEqual({
+      '@type': 'WebPage',
+      '@id': `${SITE_DOMAIN}/posts/hello-world`,
+    })
+  })
+
+  it('falls back to site description when excerpt is empty', () => {
+    const ld = buildBlogPostingJsonLd(
+      { ...basePost, excerpt: '' } as Post,
+      'hello-world'
+    )
+
+    expect(ld.description).toBeTruthy()
+    expect(ld.description).not.toBe('')
+  })
+
+  it('embeds protocol-relative image urls as https', () => {
+    const post = {
+      ...basePost,
+      featuredImage: {
+        fields: {
+          file: { fields: { file: { url: '//images.ctfassets.net/x.jpg' } } },
+        },
+      },
+    } as unknown as Post
+
+    const ld = buildBlogPostingJsonLd(post, 'hello-world') as {
+      image?: string
+    }
+    expect(ld.image).toBe('https://images.ctfassets.net/x.jpg')
+  })
+
+  it('keeps absolute https image urls untouched', () => {
+    const post = {
+      ...basePost,
+      featuredImage: {
+        fields: {
+          file: {
+            fields: { file: { url: 'https://images.example.com/x.jpg' } },
+          },
+        },
+      },
+    } as unknown as Post
+
+    const ld = buildBlogPostingJsonLd(post, 'hello-world') as {
+      image?: string
+    }
+    expect(ld.image).toBe('https://images.example.com/x.jpg')
+  })
+
+  it('includes author when provided', () => {
+    const post = {
+      ...basePost,
+      author: { fields: { name: 'Jane Doe' } },
+    } as unknown as Post
+
+    const ld = buildBlogPostingJsonLd(post, 'hello-world') as {
+      author?: { '@type': string; name: string }
+    }
+    expect(ld.author).toEqual({ '@type': 'Person', name: 'Jane Doe' })
+  })
+
+  it('omits author when missing', () => {
+    const ld = buildBlogPostingJsonLd(basePost, 'hello-world') as {
+      author?: unknown
+    }
+    expect(ld.author).toBeUndefined()
+  })
+})

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -1,0 +1,53 @@
+import { Post } from '@/typeDefinitions/app'
+import { SITE_DESCRIPTION, SITE_DOMAIN } from '@/lib/constants'
+
+/**
+ * Builds a schema.org `Person` object for the /about page.
+ */
+export function buildPersonJsonLd() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Jason Rundell',
+    jobTitle: 'Manager / Full Stack Developer',
+    url: `${SITE_DOMAIN}/about`,
+    sameAs: [
+      'https://www.linkedin.com/in/jasonrundell/',
+      'https://github.com/jasonrundell',
+    ],
+    description:
+      'AI-first Application Development Manager and Senior Full Stack Web Developer with 20+ years leading high-impact web platforms and engineering teams.',
+  }
+}
+
+/**
+ * Builds a schema.org `BlogPosting` object for a single post detail page.
+ */
+export function buildBlogPostingJsonLd(post: Post, slug: string) {
+  const rawUrl = post.featuredImage?.fields?.file?.fields?.file?.url
+  const imageUrl = rawUrl
+    ? rawUrl.startsWith('//')
+      ? `https:${rawUrl}`
+      : rawUrl.startsWith('http')
+        ? rawUrl
+        : `https:${rawUrl}`
+    : undefined
+
+  const authorName = post.author?.fields?.name
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.excerpt || SITE_DESCRIPTION,
+    datePublished: post.date,
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `${SITE_DOMAIN}/posts/${slug}`,
+    },
+    ...(imageUrl ? { image: imageUrl } : {}),
+    ...(authorName
+      ? { author: { '@type': 'Person', name: authorName } }
+      : {}),
+  }
+}

--- a/src/lib/projectUtils.test.ts
+++ b/src/lib/projectUtils.test.ts
@@ -1,0 +1,123 @@
+import { toProjectCardItem } from './projectUtils'
+import { Project } from '@/typeDefinitions/app'
+
+const baseProject: Project = {
+  title: 'Test Project',
+  slug: 'test-project',
+  order: 1,
+  excerpt: 'A test excerpt',
+  description: null as never,
+  technology: ['TypeScript'],
+}
+
+describe('toProjectCardItem', () => {
+  it('maps a project with full featuredImage data', () => {
+    const project: Project = {
+      ...baseProject,
+      featuredImage: {
+        metadata: { tags: [], concepts: [] },
+        sys: {} as never,
+        fields: {
+          title: 'Image Title',
+          altText: 'Alt text',
+          description: 'Image description',
+          file: {
+            metadata: { tags: [], concepts: [] },
+            sys: {} as never,
+            fields: {
+              title: 'File Title',
+              file: {
+                url: 'https://example.com/image.webp',
+                details: { size: 1000, image: { width: 800, height: 600 } },
+                fileName: 'image.webp',
+                contentType: 'image/webp',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = toProjectCardItem(project)
+
+    expect(result).toEqual({
+      title: 'Test Project',
+      excerpt: 'A test excerpt',
+      slug: 'test-project',
+      featuredImage: {
+        file: { url: 'https://example.com/image.webp' },
+        altText: 'Alt text',
+        description: 'Image description',
+      },
+    })
+  })
+
+  it('falls back to empty strings when featuredImage is undefined', () => {
+    const result = toProjectCardItem(baseProject)
+
+    expect(result).toEqual({
+      title: 'Test Project',
+      excerpt: 'A test excerpt',
+      slug: 'test-project',
+      featuredImage: {
+        file: { url: '' },
+        altText: '',
+        description: '',
+      },
+    })
+  })
+
+  it('falls back to empty strings when featuredImage fields are missing optional properties', () => {
+    const project: Project = {
+      ...baseProject,
+      featuredImage: {
+        metadata: { tags: [], concepts: [] },
+        sys: {} as never,
+        fields: {
+          title: 'Image Title',
+          file: {
+            metadata: { tags: [], concepts: [] },
+            sys: {} as never,
+            fields: {
+              title: 'File Title',
+              file: {
+                url: 'https://example.com/image.webp',
+                details: { size: 1000, image: { width: 800, height: 600 } },
+                fileName: 'image.webp',
+                contentType: 'image/webp',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const result = toProjectCardItem(project)
+
+    expect(result.featuredImage.altText).toBe('')
+    expect(result.featuredImage.description).toBe('')
+    expect(result.featuredImage.file.url).toBe('https://example.com/image.webp')
+  })
+
+  it('falls back to empty url when file fields are missing', () => {
+    const project: Project = {
+      ...baseProject,
+      featuredImage: {
+        metadata: { tags: [], concepts: [] },
+        sys: {} as never,
+        fields: {
+          title: 'Image Title',
+          altText: 'Alt text',
+          description: 'Desc',
+          file: undefined as never,
+        },
+      },
+    }
+
+    const result = toProjectCardItem(project)
+
+    expect(result.featuredImage.file.url).toBe('')
+    expect(result.featuredImage.altText).toBe('Alt text')
+    expect(result.featuredImage.description).toBe('Desc')
+  })
+})

--- a/src/lib/projectUtils.ts
+++ b/src/lib/projectUtils.ts
@@ -1,0 +1,17 @@
+import { Project, ProjectCardItem } from '@/typeDefinitions/app'
+
+export function toProjectCardItem(project: Project): ProjectCardItem {
+  const fields = project.featuredImage?.fields
+  const file = fields?.file?.fields?.file
+
+  return {
+    title: project.title,
+    excerpt: project.excerpt,
+    slug: project.slug,
+    featuredImage: {
+      file: { url: file?.url ?? '' },
+      altText: fields?.altText ?? '',
+      description: fields?.description ?? '',
+    },
+  }
+}

--- a/src/typeDefinitions/app.ts
+++ b/src/typeDefinitions/app.ts
@@ -58,6 +58,17 @@ export interface Projects {
   projects: Project[]
 }
 
+export type ProjectCardItem = {
+  title: string
+  featuredImage: {
+    file: { url: string }
+    altText: string
+    description: string
+  }
+  excerpt: string
+  slug: string
+}
+
 export interface FeaturedImage {
   metadata: {
     tags: string[]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it reshapes primary navigation/routing and homepage content selection logic (sorting/limits), plus injects new JSON-LD scripts that could affect SEO rendering if incorrect.
> 
> **Overview**
> Refactors the home page into a **hub layout**: removes inline skills/experience/recommendations sections, adds a `HubDoors` CTA grid, and surfaces **selected projects** (sorted by `order`, limited to 3) plus **latest posts** (sorted by `date` desc, limited to 3).
> 
> Introduces new top-level pages for **`/about`**, **`/projects`**, **`/posts`**, and **`/contact`** (each with metadata + daily ISR), and updates breadcrumbs and main navigation/mobile menu to route to these pages instead of `/#projects` and `/#blog`.
> 
> Adds SEO helpers: new `jsonld` utilities to emit schema.org `Person` (About) and `BlogPosting` (post detail) JSON-LD, plus `projectUtils` to normalize projects into the card shape used by `MoreProjects`. Extensive new Jest tests cover the new pages/components and updated homepage behavior; `.gitignore` also now ignores `certificates` and Cursor debug logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b100933b5a9717932796ecf670f43d390ef9914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->