### PR TITLE
2026 Design Updates - Phase 3

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -61,14 +61,21 @@ const nextConfig = {
               "default-src 'self'",
               // 'unsafe-inline' is required by Next.js 14 for hydration/routing inline scripts.
               // 'unsafe-eval' is only included in development for webpack HMR source maps.
+              // va.vercel-scripts.com hosts the @vercel/speed-insights runtime.
               process.env.NODE_ENV === 'development'
-                ? "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com"
-                : "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com",
+                ? "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://va.vercel-scripts.com"
+                : "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://va.vercel-scripts.com",
+              // Sentry's session replay integration spawns a Web Worker from
+              // a blob: URL. Without an explicit worker-src the browser falls
+              // back to script-src and blocks it.
+              "worker-src 'self' blob:",
               // 'unsafe-inline' is required by Pigment CSS (CSS-in-JS).
               "style-src 'self' 'unsafe-inline'",
               "img-src 'self' data: https: blob:",
               "font-src 'self' data:",
-              "connect-src 'self' https://*.supabase.co https://*.supabase.in https://www.google-analytics.com",
+              // Sentry posts events to *.ingest.sentry.io (region-prefixed).
+              // va.vercel-scripts.com receives Speed Insights vitals beacons.
+              "connect-src 'self' https://*.supabase.co https://*.supabase.in https://www.google-analytics.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://va.vercel-scripts.com",
               "frame-src 'self' https://www.youtube.com",
               "object-src 'none'",
               "base-uri 'self'",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@vercel/speed-insights": "^1.1.0",
         "contentful": "^11.3.3",
         "date-fns": "^4.1.0",
+        "geist": "^1.7.0",
         "isomorphic-dompurify": "^2.30.0",
         "lucide-react": "^0.475.0",
         "next": "^14.2.25",
@@ -8962,6 +8963,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geist": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
+      "integrity": "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=13.2.0"
       }
     },
     "node_modules/gensync": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@vercel/speed-insights": "^1.1.0",
     "contentful": "^11.3.3",
     "date-fns": "^4.1.0",
+    "geist": "^1.7.0",
     "isomorphic-dompurify": "^2.30.0",
     "lucide-react": "^0.475.0",
     "next": "^14.2.25",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import type { Metadata } from 'next'
 import { GoogleAnalytics } from '@next/third-parties/google'
-import { Outfit } from 'next/font/google'
+import { GeistSans } from 'geist/font/sans'
+import { GeistMono } from 'geist/font/mono'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 
 import { SITE_NAME, SITE_DESCRIPTION } from '@/lib/constants'
@@ -25,11 +26,6 @@ export const metadata: Metadata = {
   description: SITE_DESCRIPTION,
 }
 
-const outfit = Outfit({
-  subsets: ['latin'],
-  display: 'swap', // Prevents invisible text during font load
-})
-
 /**
  * Root layout component for the application.
  * Provides the HTML structure, metadata, and global components.
@@ -41,8 +37,8 @@ export default async function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en">
-      <body className={outfit.className}>
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
+      <body className={GeistSans.className}>
         <a href="#main-content" className="skip-link">
           Skip to main content
         </a>

--- a/src/components/HeadingAnimation.tsx
+++ b/src/components/HeadingAnimation.tsx
@@ -8,6 +8,13 @@ import Link from 'next/link'
 interface HeadingAnimationProps {
   steps: string[]
   speed: number
+  /**
+   * Stable accessible name announced to assistive tech. Defaults to the
+   * first step which represents the resting/canonical title (e.g. "Jason
+   * Rundell"). The animated visual text is hidden from the a11y tree so
+   * screen readers see one stable label, never the typewriter flicker.
+   */
+  ariaLabel?: string
 }
 
 const StyledHeading = styled(Heading)`
@@ -15,8 +22,13 @@ const StyledHeading = styled(Heading)`
   font-weight: 400;
 `
 
-const HeadingAnimation = ({ steps, speed }: HeadingAnimationProps) => {
+const HeadingAnimation = ({
+  steps,
+  speed,
+  ariaLabel,
+}: HeadingAnimationProps) => {
   const [currentStep, setCurrentStep] = useState(0)
+  const accessibleName = ariaLabel ?? steps[0]
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -33,8 +45,12 @@ const HeadingAnimation = ({ steps, speed }: HeadingAnimationProps) => {
 
   return (
     <StyledHeading level={1}>
-      <Link href="/" className="decoration--none primary-color">
-        {steps[currentStep]}
+      <Link
+        href="/"
+        className="decoration--none primary-color"
+        aria-label={accessibleName}
+      >
+        <span aria-hidden="true">{steps[currentStep]}</span>
       </Link>
     </StyledHeading>
   )

--- a/src/components/MoreProjects.tsx
+++ b/src/components/MoreProjects.tsx
@@ -1,19 +1,9 @@
 import { Grid } from '@jasonrundell/dropship'
 import ProjectPreview from './ProjectPreview'
+import { ProjectCardItem } from '@/typeDefinitions/app'
 
 interface MoreProjectsProps {
-  items: {
-    title: string
-    featuredImage: {
-      file: {
-        url: string
-      }
-      altText: string
-      description: string
-    }
-    excerpt: string
-    slug: string
-  }[]
+  items: ProjectCardItem[]
 }
 
 export default function MoreProjects({ items }: MoreProjectsProps) {

--- a/src/components/PostPreview.tsx
+++ b/src/components/PostPreview.tsx
@@ -9,7 +9,7 @@ import { StyledLink } from '@/styles/common'
 
 interface PostPreviewProps {
   title: string
-  image: {
+  image?: {
     file: {
       url: string
     }
@@ -40,7 +40,7 @@ function PostPreview({
 }: PostPreviewProps) {
   return (
     <div>
-      {image && image.file && (
+      {image?.file?.url && (
         <Row>
           <StyledImage>
             <PostPreviewImage

--- a/src/components/ProjectPreview.tsx
+++ b/src/components/ProjectPreview.tsx
@@ -7,7 +7,7 @@ import Tokens from '@/lib/tokens'
 
 interface ProjectPreviewProps {
   title: string
-  image: {
+  image?: {
     file: {
       url: string
     }
@@ -41,7 +41,7 @@ export default function ProjectPreview({
 }: ProjectPreviewProps) {
   return (
     <div>
-      {image && image.file && (
+      {image?.file?.url && (
         <Row>
           <StyledImage>
             <ProjectPreviewImage

--- a/src/components/content-display.test.tsx
+++ b/src/components/content-display.test.tsx
@@ -346,27 +346,49 @@ describe('content display components', () => {
     expect(screen.getByText('By: Post Author')).toBeInTheDocument()
   })
 
-  it('advances heading animation until the last step', () => {
+  it('advances heading animation until the last step while keeping a stable accessible name', () => {
     jest.useFakeTimers()
 
     render(<HeadingAnimation steps={['J', 'Ja', 'Jason']} speed={100} />)
 
-    expect(screen.getByRole('link', { name: 'J' })).toHaveAttribute('href', '/')
+    // The link's accessible name is stable across ticks (defaults to steps[0])
+    // so screen readers do not announce every typewriter frame.
+    const link = screen.getByRole('link', { name: 'J' })
+    expect(link).toHaveAttribute('href', '/')
+    expect(link).toHaveAttribute('aria-label', 'J')
+    expect(screen.getByText('J')).toHaveAttribute('aria-hidden', 'true')
 
     act(() => {
       jest.advanceTimersByTime(100)
     })
-    expect(screen.getByRole('link', { name: 'Ja' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'J' })).toBeInTheDocument()
+    expect(screen.getByText('Ja')).toHaveAttribute('aria-hidden', 'true')
 
     act(() => {
       jest.advanceTimersByTime(100)
     })
-    expect(screen.getByRole('link', { name: 'Jason' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'J' })).toBeInTheDocument()
+    expect(screen.getByText('Jason')).toHaveAttribute('aria-hidden', 'true')
 
     act(() => {
       jest.advanceTimersByTime(100)
     })
-    expect(screen.getByRole('link', { name: 'Jason' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'J' })).toBeInTheDocument()
+    expect(screen.getByText('Jason')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('uses the explicit ariaLabel prop when provided so consumers control the accessible name', () => {
+    render(
+      <HeadingAnimation
+        steps={['J', 'Ja', 'Jason']}
+        speed={100}
+        ariaLabel="Jason Rundell home"
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'Jason Rundell home' })
+    expect(link).toHaveAttribute('href', '/')
+    expect(link).toHaveAttribute('aria-label', 'Jason Rundell home')
   })
 
   it('scrolls back to top by click and keyboard activation', () => {

--- a/src/lib/common.tokens.json
+++ b/src/lib/common.tokens.json
@@ -153,15 +153,15 @@
       "unit": "hex"
     },
     "background": {
-      "value": "#232f3e",
+      "value": "#151c25",
       "unit": "hex"
     },
     "backgroundDark": {
-      "value": "#1c2531",
+      "value": "#0e131a",
       "unit": "hex"
     },
     "backgroundDarker": {
-      "value": "#151c25",
+      "value": "#0e131a",
       "unit": "hex"
     },
     "surface": {
@@ -169,7 +169,7 @@
       "unit": "hex"
     },
     "textPrimary": {
-      "value": "#9aaec6",
+      "value": "#b8c5d6",
       "unit": "hex"
     },
     "textSecondary": {
@@ -189,7 +189,7 @@
       "unit": "hex"
     },
     "success": {
-      "value": "#63db53",
+      "value": "#9ece6a",
       "unit": "hex"
     },
     "warning": {
@@ -197,7 +197,7 @@
       "unit": "hex"
     },
     "error": {
-      "value": "#d93f3f",
+      "value": "#f7768e",
       "unit": "hex"
     },
     "white": {
@@ -209,7 +209,7 @@
       "unit": "hex"
     },
     "roleSuccess": {
-      "value": "#63db53",
+      "value": "#9ece6a",
       "unit": "hex"
     },
     "roleInfo": {
@@ -217,11 +217,11 @@
       "unit": "hex"
     },
     "roleDanger": {
-      "value": "#d93f3f",
+      "value": "#f7768e",
       "unit": "hex"
     },
     "roleBody": {
-      "value": "#9aaec6",
+      "value": "#b8c5d6",
       "unit": "hex"
     },
     "roleHeading": {
@@ -229,15 +229,15 @@
       "unit": "hex"
     },
     "surfaceBase": {
-      "value": "#232f3e",
+      "value": "#151c25",
       "unit": "hex"
     },
     "surfaceElevated": {
-      "value": "#1c2531",
+      "value": "#232f3e",
       "unit": "hex"
     },
     "surfaceDeepest": {
-      "value": "#151c25",
+      "value": "#0e131a",
       "unit": "hex"
     },
     "surfaceOverlay": {
@@ -345,16 +345,16 @@
   },
   "fonts": {
     "body": {
-      "family": "Outfit, Arial, sans-serif"
+      "family": "var(--font-geist-sans), Geist, system-ui, sans-serif"
     },
     "heading": {
-      "family": "Georgia, serif"
+      "family": "var(--font-geist-sans), Geist, system-ui, sans-serif"
     },
     "monospace": {
-      "family": "Courier New, monospace"
+      "family": "var(--font-geist-mono), 'Geist Mono', ui-monospace, 'Courier New', monospace"
     },
     "quotes": {
-      "family": "'Times New Roman', Times, serif"
+      "family": "var(--font-geist-sans), Geist, system-ui, sans-serif"
     }
   },
   "### NOTES ###": {

--- a/src/lib/projectUtils.test.ts
+++ b/src/lib/projectUtils.test.ts
@@ -52,22 +52,18 @@ describe('toProjectCardItem', () => {
     })
   })
 
-  it('falls back to empty strings when featuredImage is undefined', () => {
+  it('omits featuredImage when the source project has no image', () => {
     const result = toProjectCardItem(baseProject)
 
     expect(result).toEqual({
       title: 'Test Project',
       excerpt: 'A test excerpt',
       slug: 'test-project',
-      featuredImage: {
-        file: { url: '' },
-        altText: '',
-        description: '',
-      },
     })
+    expect(result.featuredImage).toBeUndefined()
   })
 
-  it('falls back to empty strings when featuredImage fields are missing optional properties', () => {
+  it('defaults missing alt text and description to empty strings when an image url is present', () => {
     const project: Project = {
       ...baseProject,
       featuredImage: {
@@ -94,12 +90,14 @@ describe('toProjectCardItem', () => {
 
     const result = toProjectCardItem(project)
 
-    expect(result.featuredImage.altText).toBe('')
-    expect(result.featuredImage.description).toBe('')
-    expect(result.featuredImage.file.url).toBe('https://example.com/image.webp')
+    expect(result.featuredImage).toEqual({
+      file: { url: 'https://example.com/image.webp' },
+      altText: '',
+      description: '',
+    })
   })
 
-  it('falls back to empty url when file fields are missing', () => {
+  it('omits featuredImage when the file fields are missing', () => {
     const project: Project = {
       ...baseProject,
       featuredImage: {
@@ -116,8 +114,6 @@ describe('toProjectCardItem', () => {
 
     const result = toProjectCardItem(project)
 
-    expect(result.featuredImage.file.url).toBe('')
-    expect(result.featuredImage.altText).toBe('Alt text')
-    expect(result.featuredImage.description).toBe('Desc')
+    expect(result.featuredImage).toBeUndefined()
   })
 })

--- a/src/lib/projectUtils.ts
+++ b/src/lib/projectUtils.ts
@@ -1,15 +1,31 @@
 import { Project, ProjectCardItem } from '@/typeDefinitions/app'
 
+/**
+ * Map a Contentful Project entry to the lightweight shape consumed by card
+ * components. featuredImage is omitted when the source has no usable file
+ * URL — downstream components must treat the image as optional rather than
+ * receiving a synthesised empty string (which Next/Image rejects with a
+ * "missing required `src` property" warning at runtime).
+ */
 export function toProjectCardItem(project: Project): ProjectCardItem {
   const fields = project.featuredImage?.fields
   const file = fields?.file?.fields?.file
+  const url = file?.url
 
-  return {
+  const base: ProjectCardItem = {
     title: project.title,
     excerpt: project.excerpt,
     slug: project.slug,
+  }
+
+  if (!url) {
+    return base
+  }
+
+  return {
+    ...base,
     featuredImage: {
-      file: { url: file?.url ?? '' },
+      file: { url },
       altText: fields?.altText ?? '',
       description: fields?.description ?? '',
     },

--- a/src/lib/tokens.generated.ts
+++ b/src/lib/tokens.generated.ts
@@ -195,17 +195,17 @@ const Tokens = {
       "var": "var(--color-accent)"
     },
     "background": {
-      "value": "#232f3e",
+      "value": "#151c25",
       "unit": "hex",
       "var": "var(--color-background)"
     },
     "backgroundDark": {
-      "value": "#1c2531",
+      "value": "#0e131a",
       "unit": "hex",
       "var": "var(--color-background-dark)"
     },
     "backgroundDarker": {
-      "value": "#151c25",
+      "value": "#0e131a",
       "unit": "hex",
       "var": "var(--color-background-darker)"
     },
@@ -215,7 +215,7 @@ const Tokens = {
       "var": "var(--color-surface)"
     },
     "textPrimary": {
-      "value": "#9aaec6",
+      "value": "#b8c5d6",
       "unit": "hex",
       "var": "var(--color-text-primary)"
     },
@@ -240,7 +240,7 @@ const Tokens = {
       "var": "var(--color-muted)"
     },
     "success": {
-      "value": "#63db53",
+      "value": "#9ece6a",
       "unit": "hex",
       "var": "var(--color-success)"
     },
@@ -250,7 +250,7 @@ const Tokens = {
       "var": "var(--color-warning)"
     },
     "error": {
-      "value": "#d93f3f",
+      "value": "#f7768e",
       "unit": "hex",
       "var": "var(--color-error)"
     },
@@ -265,7 +265,7 @@ const Tokens = {
       "var": "var(--color-role-prompt)"
     },
     "roleSuccess": {
-      "value": "#63db53",
+      "value": "#9ece6a",
       "unit": "hex",
       "var": "var(--color-role-success)"
     },
@@ -275,12 +275,12 @@ const Tokens = {
       "var": "var(--color-role-info)"
     },
     "roleDanger": {
-      "value": "#d93f3f",
+      "value": "#f7768e",
       "unit": "hex",
       "var": "var(--color-role-danger)"
     },
     "roleBody": {
-      "value": "#9aaec6",
+      "value": "#b8c5d6",
       "unit": "hex",
       "var": "var(--color-role-body)"
     },
@@ -290,17 +290,17 @@ const Tokens = {
       "var": "var(--color-role-heading)"
     },
     "surfaceBase": {
-      "value": "#232f3e",
+      "value": "#151c25",
       "unit": "hex",
       "var": "var(--color-surface-base)"
     },
     "surfaceElevated": {
-      "value": "#1c2531",
+      "value": "#232f3e",
       "unit": "hex",
       "var": "var(--color-surface-elevated)"
     },
     "surfaceDeepest": {
-      "value": "#151c25",
+      "value": "#0e131a",
       "unit": "hex",
       "var": "var(--color-surface-deepest)"
     },
@@ -432,19 +432,19 @@ const Tokens = {
   },
   "fonts": {
     "body": {
-      "family": "Outfit, Arial, sans-serif",
+      "family": "var(--font-geist-sans), Geist, system-ui, sans-serif",
       "var": "var(--font-family-body)"
     },
     "heading": {
-      "family": "Georgia, serif",
+      "family": "var(--font-geist-sans), Geist, system-ui, sans-serif",
       "var": "var(--font-family-heading)"
     },
     "monospace": {
-      "family": "Courier New, monospace",
+      "family": "var(--font-geist-mono), 'Geist Mono', ui-monospace, 'Courier New', monospace",
       "var": "var(--font-family-monospace)"
     },
     "quotes": {
-      "family": "'Times New Roman', Times, serif",
+      "family": "var(--font-geist-sans), Geist, system-ui, sans-serif",
       "var": "var(--font-family-quotes)"
     }
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -73,13 +73,13 @@ hr {
 
 @property --background-color-start {
   syntax: '<color>';
-  initial-value: #232f3e;
+  initial-value: #151c25;
   inherits: false;
 }
 
 @property --background-color-end {
   syntax: '<color>';
-  initial-value: #232f3e;
+  initial-value: #151c25;
   inherits: false;
 }
 
@@ -101,13 +101,13 @@ hr {
     var(--background-color-start) 0%,
     var(--background-color-end) 100%
   );
-  --background-color-start: #232f3e;
-  --background-color-end: #151c25;
+  --background-color-start: #151c25;
+  --background-color-end: #0e131a;
 }
 
 #menu:not(.scrolled) {
-  --background-color-start: #232f3e;
-  --background-color-end: #232f3e;
+  --background-color-start: #151c25;
+  --background-color-end: #151c25;
 }
 
 .decoration--none {
@@ -158,5 +158,24 @@ select:focus-visible {
 @media (min-width: 48rem) {
   .youtube-embed {
     height: 31.25rem;
+  }
+}
+
+/*
+ * Global motion guard. Honours users who request reduced motion at the OS
+ * level so every animation/transition collapses to a near-instant settled
+ * state. Components with motion logic (HeroTerminal, Tier 2 reveals) read
+ * the same media query and bypass their effects accordingly.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-delay: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
   }
 }

--- a/src/styles/tokens.generated.css
+++ b/src/styles/tokens.generated.css
@@ -43,28 +43,28 @@
   --color-secondary: #eeeeee;
   --color-secondary-variant: #018786;
   --color-accent: #ff4081;
-  --color-background: #232f3e;
-  --color-background-dark: #1c2531;
-  --color-background-darker: #151c25;
+  --color-background: #151c25;
+  --color-background-dark: #0e131a;
+  --color-background-darker: #0e131a;
   --color-surface: #000000;
-  --color-text-primary: #9aaec6;
+  --color-text-primary: #b8c5d6;
   --color-text-secondary: #757575;
   --color-border: #dddddd;
   --color-link: #0070f3;
   --color-muted: #f6f6f6;
-  --color-success: #63db53;
+  --color-success: #9ece6a;
   --color-warning: #f5a623;
-  --color-error: #d93f3f;
+  --color-error: #f7768e;
   --color-white: #ffffff;
   --color-role-prompt: #e9be62;
-  --color-role-success: #63db53;
+  --color-role-success: #9ece6a;
   --color-role-info: #7dd3c0;
-  --color-role-danger: #d93f3f;
-  --color-role-body: #9aaec6;
+  --color-role-danger: #f7768e;
+  --color-role-body: #b8c5d6;
   --color-role-heading: #eeeeee;
-  --color-surface-base: #232f3e;
-  --color-surface-elevated: #1c2531;
-  --color-surface-deepest: #151c25;
+  --color-surface-base: #151c25;
+  --color-surface-elevated: #232f3e;
+  --color-surface-deepest: #0e131a;
   --color-surface-overlay: #000000;
 
   /* fontSizes */
@@ -100,8 +100,8 @@
   --z-index-modal-content: 10000;
 
   /* fonts */
-  --font-family-body: Outfit, Arial, sans-serif;
-  --font-family-heading: Georgia, serif;
-  --font-family-monospace: Courier New, monospace;
-  --font-family-quotes: 'Times New Roman', Times, serif;
+  --font-family-body: var(--font-geist-sans), Geist, system-ui, sans-serif;
+  --font-family-heading: var(--font-geist-sans), Geist, system-ui, sans-serif;
+  --font-family-monospace: var(--font-geist-mono), 'Geist Mono', ui-monospace, 'Courier New', monospace;
+  --font-family-quotes: var(--font-geist-sans), Geist, system-ui, sans-serif;
 }

--- a/src/typeDefinitions/app.ts
+++ b/src/typeDefinitions/app.ts
@@ -60,7 +60,7 @@ export interface Projects {
 
 export type ProjectCardItem = {
   title: string
-  featuredImage: {
+  featuredImage?: {
     file: { url: string }
     altText: string
     description: string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk due to changes to the global `Content-Security-Policy` and image/null-handling paths, which could break third-party scripts/workers or suppress images if assumptions are wrong. Remaining changes are largely visual/a11y improvements with straightforward test coverage.
> 
> **Overview**
> Updates global security headers to support **Vercel Speed Insights** and **Sentry** by allowing `va.vercel-scripts.com`, adding `worker-src blob:`, and expanding `connect-src` to Sentry ingest endpoints.
> 
> Refreshes the site’s typography and theme by adding `geist` and switching the root layout + design tokens to Geist Sans/Mono, alongside updated color tokens and menu gradient values.
> 
> Improves UX/accessibility by adding a global `prefers-reduced-motion` guard and making `HeadingAnimation` expose a stable accessible name (`ariaLabel`) while hiding the animated text from the a11y tree.
> 
> Hardens Contentful image handling by making `ProjectCardItem.featuredImage` optional, updating project mapping to *omit* missing/invalid image URLs (instead of empty strings), and adjusting preview components/tests to treat images as optional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89e3154e3fe769749d810e13fb09acc12587167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->