### PR TITLE
2026 Design Updates: Phase 4

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,8 +12,6 @@ import {
 import {
   StyledContainer,
   StyledIntroParagraph,
-  StyledList,
-  StyledListItem,
   StyledSection,
   StyledLink,
   StyledBreadcrumb,
@@ -23,6 +21,7 @@ import Skills from '@/components/Skills'
 import References from '@/components/References'
 import Positions from '@/components/Positions'
 import Icon from '@/components/Icon'
+import { SectionHeading, PromptList } from '@/components/chrome'
 import { buildPersonJsonLd } from '@/lib/jsonld'
 
 export const metadata = {
@@ -82,19 +81,19 @@ export default async function AboutPage() {
       </StyledSection>
 
       <StyledSection id="skills">
-        <h2>Skills</h2>
+        <SectionHeading comment="skills.tsx">Skills</SectionHeading>
         <Row>{skills && <Skills skills={skills} />}</Row>
       </StyledSection>
 
       <StyledSection id="experience">
-        <h2>Experience</h2>
+        <SectionHeading comment="experience.tsx">Experience</SectionHeading>
         <Row>
           {positions.length > 0 && <Positions positions={positions} />}
         </Row>
         <Spacer />
         <Row>
-          <StyledList>
-            <StyledListItem>
+          <PromptList aria-label="More experience links">
+            <PromptList.Item>
               <Icon type="LinkedIn" />{' '}
               <StyledLink
                 href="https://www.linkedin.com/in/jasonrundell/"
@@ -104,13 +103,15 @@ export default async function AboutPage() {
               >
                 <ExternalLink size={18} /> See more on LinkedIn
               </StyledLink>
-            </StyledListItem>
-          </StyledList>
+            </PromptList.Item>
+          </PromptList>
         </Row>
       </StyledSection>
 
       <StyledSection id="recommendations">
-        <h2>Recommendations</h2>
+        <SectionHeading comment="recommendations.tsx">
+          Recommendations
+        </SectionHeading>
         <Row>
           {references.length > 0 && <References references={references} />}
         </Row>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,11 @@ import {
 import MorePosts from '@/components/MorePosts'
 import MoreProjects from '@/components/MoreProjects'
 import HubDoors, { HubDoor } from '@/components/HubDoors'
+import {
+  SectionHeading,
+  HeroConstDeclaration,
+  HeroConstField,
+} from '@/components/chrome'
 import HeroImage from '@/public/images/ai-powered-developer.webp'
 
 const LastSongWrapper = dynamic(() => import('@/components/LastSongWrapper'), {
@@ -43,6 +48,16 @@ const HUB_DOORS: ReadonlyArray<HubDoor> = [
     href: '/posts',
     label: 'Blog',
     description: 'Notes on the web, engineering, and AI-assisted work.',
+  },
+] as const
+
+const HERO_FIELDS: ReadonlyArray<HeroConstField> = [
+  { key: 'name', value: 'Jason Rundell' },
+  { key: 'role', value: 'Manager / Full Stack Developer' },
+  {
+    key: 'pitch',
+    value:
+      'AI-first ADM and Senior Full Stack Web Developer with 20+ years leading high-impact web platforms.',
   },
 ] as const
 
@@ -83,6 +98,9 @@ export default async function HomePage() {
       <StyledContainer>
         <StyledSection id="home">
           <h1>Manager / Full Stack Developer</h1>
+          <Spacer />
+          <HeroConstDeclaration fields={HERO_FIELDS} />
+          <Spacer />
           <StyledImageContainer>
             <Image
               src={HeroImage}
@@ -122,7 +140,9 @@ export default async function HomePage() {
         </StyledSection>
 
         <StyledSection id="selected-projects">
-          <h2>Selected projects</h2>
+          <SectionHeading comment="selected-projects.tsx">
+            Selected projects
+          </SectionHeading>
           <Row>
             <MoreProjects items={selectedProjects.map(toProjectCardItem)} />
           </Row>
@@ -133,7 +153,9 @@ export default async function HomePage() {
         <StyledContainer>
           <StyledSection id="latest-posts">
             <Spacer />
-            <h2>Latest posts</h2>
+            <SectionHeading comment="latest-posts.tsx">
+              Latest posts
+            </SectionHeading>
             <Spacer />
             <Row>
               <MorePosts posts={latestPosts} />

--- a/src/components/ContactList.tsx
+++ b/src/components/ContactList.tsx
@@ -1,11 +1,12 @@
 import Icon from './Icon'
 import { ExternalLink } from 'lucide-react'
-import { StyledList, StyledListItem, StyledLink } from '@/styles/common'
+import { StyledLink } from '@/styles/common'
+import PromptList from '@/components/chrome/PromptList'
 
 export default function ContactList() {
   return (
-    <StyledList>
-      <StyledListItem>
+    <PromptList aria-label="Ways to reach me">
+      <PromptList.Item>
         <Icon type="Email" />{' '}
         <StyledLink
           href="mailto:contact@jasonrundell.com"
@@ -13,8 +14,8 @@ export default function ContactList() {
         >
           Email me
         </StyledLink>
-      </StyledListItem>
-      <StyledListItem>
+      </PromptList.Item>
+      <PromptList.Item>
         <Icon type="Calendar" />{' '}
         <StyledLink
           href="https://calendly.com/jason-rundell/60-minute-meeting"
@@ -24,8 +25,8 @@ export default function ContactList() {
         >
           <ExternalLink size={18} /> Book time with me
         </StyledLink>
-      </StyledListItem>
-      <StyledListItem>
+      </PromptList.Item>
+      <PromptList.Item>
         <Icon type="GitHub" />{' '}
         <StyledLink
           href="https://github.com/jasonrundell?tab=repositories&q=&type=&language=&sort="
@@ -35,8 +36,8 @@ export default function ContactList() {
         >
           <ExternalLink size={18} /> My open-source work on GitHub
         </StyledLink>
-      </StyledListItem>
-      <StyledListItem>
+      </PromptList.Item>
+      <PromptList.Item>
         <Icon type="LinkedIn" />{' '}
         <StyledLink
           href="https://www.linkedin.com/in/jasonrundell/"
@@ -46,7 +47,7 @@ export default function ContactList() {
         >
           <ExternalLink size={18} /> Connect on LinkedIn
         </StyledLink>
-      </StyledListItem>
-    </StyledList>
+      </PromptList.Item>
+    </PromptList>
   )
 }

--- a/src/components/ContentDate.tsx
+++ b/src/components/ContentDate.tsx
@@ -1,13 +1,14 @@
-import { format } from 'date-fns'
+import MetaDate from '@/components/chrome/MetaDate'
 
 interface ContentDateProps {
   dateString: string
 }
 
+/**
+ * Thin compatibility wrapper that delegates to the chrome `MetaDate` so all
+ * existing callers (`PostAuthor`, etc.) inherit the refined-terminal cyan
+ * `// date` styling without changing import sites.
+ */
 export default function ContentDate({ dateString }: ContentDateProps) {
-  return (
-    <time dateTime={dateString}>
-      {format(new Date(dateString), 'LLLL	d, yyyy')}
-    </time>
-  )
+  return <MetaDate dateString={dateString} />
 }

--- a/src/components/HubDoors.tsx
+++ b/src/components/HubDoors.tsx
@@ -1,7 +1,7 @@
-import Link from 'next/link'
 import { styled } from '@pigment-css/react'
 
 import Tokens from '@/lib/tokens'
+import { TerminalButtonLink } from '@/components/chrome'
 
 export type HubDoor = {
   href: string
@@ -39,39 +39,10 @@ const StyledDoorItem = styled('li')`
   padding: 0;
 `
 
-const StyledDoor = styled(Link)`
-  display: flex;
-  flex-direction: column;
-  gap: ${Tokens.sizes.small.value}${Tokens.sizes.small.unit};
-  padding: ${Tokens.sizes.large.value}${Tokens.sizes.large.unit};
-  border: 1px solid ${Tokens.colors.surfaceDeepest.var};
-  background: ${Tokens.colors.surfaceElevated.var};
-  color: ${Tokens.colors.roleHeading.var};
-  text-decoration: none;
-  border-radius: ${Tokens.borderRadius.medium.value}${Tokens.borderRadius
-      .medium.unit};
-  transition: border-color 0.15s ease;
-
-  &:hover,
-  &:focus-visible {
-    border-color: ${Tokens.colors.rolePrompt.var};
-  }
-`
-
-const StyledDoorLabel = styled('span')`
-  font-weight: 700;
-  font-size: ${Tokens.sizes.medium.value}${Tokens.sizes.medium.unit};
-`
-
-const StyledDoorDescription = styled('span')`
-  font-size: ${Tokens.sizes.fonts.small.value}${Tokens.sizes.fonts.small.unit};
-  color: ${Tokens.colors.roleBody.var};
-`
-
 /**
- * Hub doors — a small navigation grid of CTA cards that sends visitors to the
- * site's main sub-pages. Phase 4 will restyle these as terminal-style buttons;
- * keeping the markup behind a single component preserves a stable interface.
+ * Hub doors — the primary 3-door navigation grid on `/`. Phase 4 swaps the
+ * card style for terminal-button chrome via `TerminalButtonLink` so the
+ * visual language matches the rest of the refined-terminal aesthetic.
  */
 export default function HubDoors({
   doors,
@@ -82,10 +53,11 @@ export default function HubDoors({
       <StyledDoorList>
         {doors.map((door) => (
           <StyledDoorItem key={door.href}>
-            <StyledDoor href={door.href}>
-              <StyledDoorLabel>{door.label}</StyledDoorLabel>
-              <StyledDoorDescription>{door.description}</StyledDoorDescription>
-            </StyledDoor>
+            <TerminalButtonLink
+              href={door.href}
+              label={door.label}
+              description={door.description}
+            />
           </StyledDoorItem>
         ))}
       </StyledDoorList>

--- a/src/components/Positions.tsx
+++ b/src/components/Positions.tsx
@@ -1,24 +1,5 @@
-import { styled } from '@pigment-css/react'
-
 import { Position, Positions as PositionsDef } from '@/typeDefinitions/app'
-import Tokens from '@/lib/tokens'
-
-const StyledList = styled('ul')`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-`
-
-const StyledListItem = styled('li')`
-  margin: 0 0 ${Tokens.sizes.large.value}${Tokens.sizes.large.unit} 0;
-`
-
-const StyledCompany = styled('span')`
-  font-style: normal;
-`
+import PromptList from '@/components/chrome/PromptList'
 
 export default function Positions({ positions }: PositionsDef) {
   const uniquePositions = positions.filter(
@@ -27,19 +8,10 @@ export default function Positions({ positions }: PositionsDef) {
   )
 
   return (
-    <StyledList>
-      {uniquePositions.map((position: Position, index: number) => {
-        const { company } = position
-        return (
-          <StyledListItem key={index}>
-            {/* <Heading level={3}>{role}</Heading> */}
-            <StyledCompany>{company}</StyledCompany>
-            {/* <br /> */}
-            {/* <StyledDate>{startDate}</StyledDate> -{' '} */}
-            {/* <StyledDate>{endDate}</StyledDate> */}
-          </StyledListItem>
-        )
-      })}
-    </StyledList>
+    <PromptList aria-label="Companies">
+      {uniquePositions.map((position: Position, index: number) => (
+        <PromptList.Item key={index}>{position.company}</PromptList.Item>
+      ))}
+    </PromptList>
   )
 }

--- a/src/components/PostPreview.tsx
+++ b/src/components/PostPreview.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import { Spacer, Row } from '@jasonrundell/dropship'
 import { styled } from '@pigment-css/react'
 
-import ContentDate from './ContentDate'
 import PostPreviewImage from './PostPreviewImage'
 import Tokens from '@/lib/tokens'
 import { StyledLink } from '@/styles/common'
+import MetaDate from '@/components/chrome/MetaDate'
 
 interface PostPreviewProps {
   title: string
@@ -54,13 +54,11 @@ function PostPreview({
       )}
       <Row>
         <StyledHeading>
-          <StyledLink href={`/posts/${slug}`}>
-            {title}
-          </StyledLink>
+          <StyledLink href={`/posts/${slug}`}>{title}</StyledLink>
         </StyledHeading>
       </Row>
       <Row>
-        <ContentDate dateString={date} />
+        <MetaDate dateString={date} />
       </Row>
       <Row>
         <p>{excerpt}</p>

--- a/src/components/ProjectPreview.tsx
+++ b/src/components/ProjectPreview.tsx
@@ -1,9 +1,9 @@
-import Link from 'next/link'
 import { Spacer, Row } from '@jasonrundell/dropship'
 import { styled } from '@pigment-css/react'
 
 import ProjectPreviewImage from './ProjectPreviewImage'
 import Tokens from '@/lib/tokens'
+import { StyledLink } from '@/styles/common'
 
 interface ProjectPreviewProps {
   title: string
@@ -55,7 +55,7 @@ export default function ProjectPreview({
       <Spacer />
       <Row>
         <StyledHeading>
-          <Link href={`/projects/${slug}`}>{title}</Link>
+          <StyledLink href={`/projects/${slug}`}>{title}</StyledLink>
         </StyledHeading>
       </Row>
       <Spacer />

--- a/src/components/References.tsx
+++ b/src/components/References.tsx
@@ -69,10 +69,14 @@ const StyledCite = styled('span')`
 `
 
 const StyledCompany = styled('span')`
+  font-family: ${Tokens.fonts.monospace.family};
   font-size: ${Tokens.fontSizes.sm.value}${Tokens.fontSizes.sm.unit};
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: ${Tokens.colors.textSecondary.var};
+  letter-spacing: 0.04em;
+  color: ${Tokens.colors.roleInfo.var};
+
+  &::before {
+    content: '// ';
+  }
 `
 
 function ensureField<Value>(value: Value, label: string, index: number): Value {

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -4,6 +4,7 @@ import { Skill, Skills as SkillsDef } from '@/typeDefinitions/app'
 
 import { onlyUnique } from '@/lib/onlyUnique'
 import Tokens from '@/lib/tokens'
+import PromptList from '@/components/chrome/PromptList'
 
 const StyledListContainer = styled('div')`
   display: flex;
@@ -15,38 +16,18 @@ const StyledListContainer = styled('div')`
   width: 100%;
 `
 
-const StyledList = styled('ul')`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  margin-top: 0;
-  list-style: none;
-  padding-left: 0;
-`
-
-const StyledListItem = styled('li')`
-  display: inline;
-  margin-right: ${Tokens.sizes.small.value}${Tokens.sizes.small.unit};
-  margin-left: 0;
-  color: ${Tokens.colors.roleBody.var};
-  margin: 0 ${Tokens.sizes.small.value}${Tokens.sizes.small.unit} 0 0;
-  line-height: 1.6;
-`
-
 const StyledHeading = styled('h3')`
   font-size: ${Tokens.sizes.medium.value}${Tokens.sizes.medium.unit};
-  margin: 0;
+  margin: 0 0 ${Tokens.sizes.xsmall.value}${Tokens.sizes.xsmall.unit} 0;
 `
 
 export default function Skills({ skills }: SkillsDef) {
   const categories: string[] = []
 
-  // Build array of categories
   skills.forEach((skill: Skill) => {
     categories.push(skill.category)
   })
 
-  // I only want the unique categories
   const uniqueCategories = categories.filter(onlyUnique)
 
   return (
@@ -54,13 +35,13 @@ export default function Skills({ skills }: SkillsDef) {
       {uniqueCategories.map((parentCategory, index) => (
         <StyledListContainer key={index}>
           <StyledHeading>{parentCategory}</StyledHeading>
-          <StyledList>
+          <PromptList aria-label={`${parentCategory} skills`}>
             {skills
               .filter((skill: Skill) => skill.category === parentCategory)
               .map((skill: Skill) => (
-                <StyledListItem key={skill.id}>{skill.name}</StyledListItem>
+                <PromptList.Item key={skill.id}>{skill.name}</PromptList.Item>
               ))}
-          </StyledList>
+          </PromptList>
         </StyledListContainer>
       ))}
     </Row>

--- a/src/components/chrome/HeroConstDeclaration.test.tsx
+++ b/src/components/chrome/HeroConstDeclaration.test.tsx
@@ -1,0 +1,81 @@
+import { render } from '@testing-library/react'
+import HeroConstDeclaration from './HeroConstDeclaration'
+
+describe('HeroConstDeclaration', () => {
+  it('renders the const block as decorative (aria-hidden) so the page h1 stays the announced heading', () => {
+    const { container } = render(
+      <HeroConstDeclaration
+        fields={[
+          { key: 'name', value: 'Jason Rundell' },
+          { key: 'role', value: 'Manager / Full Stack Developer' },
+        ]}
+      />
+    )
+
+    const pre = container.querySelector('pre')
+    expect(pre).toBeInTheDocument()
+    expect(pre).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('renders the comment header, identifier, and field key/value pairs', () => {
+    const { container } = render(
+      <HeroConstDeclaration
+        comment="hero.tsx"
+        identifier="session"
+        fields={[
+          { key: 'name', value: 'Jason Rundell' },
+          { key: 'role', value: 'Manager / Full Stack Developer' },
+        ]}
+      />
+    )
+
+    const pre = container.querySelector('pre')
+    expect(pre?.textContent).toContain('// hero.tsx')
+    expect(pre?.textContent).toContain('const')
+    expect(pre?.textContent).toContain('session')
+    expect(pre?.textContent).toContain('name')
+    expect(pre?.textContent).toContain("'Jason Rundell'")
+    expect(pre?.textContent).toContain('role')
+    expect(pre?.textContent).toContain("'Manager / Full Stack Developer'")
+  })
+
+  it('uses default comment "hero.tsx" and identifier "session" when omitted', () => {
+    const { container } = render(
+      <HeroConstDeclaration fields={[{ key: 'name', value: 'X' }]} />
+    )
+
+    const pre = container.querySelector('pre')
+    expect(pre?.textContent).toContain('// hero.tsx')
+    expect(pre?.textContent).toContain('session')
+  })
+
+  it('handles the single-field case without trailing-comma errors', () => {
+    const { container } = render(
+      <HeroConstDeclaration fields={[{ key: 'pitch', value: 'Hello' }]} />
+    )
+
+    const pre = container.querySelector('pre')
+    expect(pre?.textContent).toContain('pitch')
+    expect(pre?.textContent).toContain("'Hello'")
+  })
+
+  it('renders one key/value entry per field', () => {
+    const { container } = render(
+      <HeroConstDeclaration
+        fields={[
+          { key: 'a', value: '1' },
+          { key: 'b', value: '2' },
+          { key: 'c', value: '3' },
+        ]}
+      />
+    )
+
+    const text = container.querySelector('pre')?.textContent ?? ''
+    expect(text).toContain('a')
+    expect(text).toContain('b')
+    expect(text).toContain('c')
+    expect(text).toContain("'1'")
+    expect(text).toContain("'2'")
+    expect(text).toContain("'3'")
+  })
+})

--- a/src/components/chrome/HeroConstDeclaration.test.tsx
+++ b/src/components/chrome/HeroConstDeclaration.test.tsx
@@ -59,6 +59,23 @@ describe('HeroConstDeclaration', () => {
     expect(pre?.textContent).toContain("'Hello'")
   })
 
+  it('omits the trailing comma after the last field and keeps commas on preceding fields', () => {
+    const { container } = render(
+      <HeroConstDeclaration
+        fields={[
+          { key: 'first', value: 'A' },
+          { key: 'last', value: 'B' },
+        ]}
+      />
+    )
+
+    const text = container.querySelector('pre')?.textContent ?? ''
+    // The text contains "first: 'A'," followed by a newline
+    expect(text).toMatch(/'A',/)
+    // The final field value is NOT followed by a comma before the closing brace
+    expect(text).toMatch(/'B'\n}/)
+  })
+
   it('renders one key/value entry per field', () => {
     const { container } = render(
       <HeroConstDeclaration

--- a/src/components/chrome/HeroConstDeclaration.tsx
+++ b/src/components/chrome/HeroConstDeclaration.tsx
@@ -77,7 +77,7 @@ export default function HeroConstDeclaration({
           <StyledKey>{field.key}</StyledKey>
           {': '}
           <StyledString>{`'${field.value}'`}</StyledString>
-          {index < fields.length - 1 ? ',\n' : ',\n'}
+          {index < fields.length - 1 ? ',\n' : '\n'}
         </React.Fragment>
       ))}
       {'}'}

--- a/src/components/chrome/HeroConstDeclaration.tsx
+++ b/src/components/chrome/HeroConstDeclaration.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { styled } from '@pigment-css/react'
+
+import Tokens from '@/lib/tokens'
+
+const StyledPre = styled('pre')`
+  font-family: ${Tokens.fonts.monospace.family};
+  font-size: ${Tokens.sizes.fonts.small.value}${Tokens.sizes.fonts.small.unit};
+  line-height: 1.6;
+  color: ${Tokens.colors.roleBody.var};
+  background-color: ${Tokens.colors.surfaceDeepest.var};
+  border: 1px solid ${Tokens.colors.surfaceElevated.var};
+  border-radius: ${Tokens.borderRadius.medium.value}${Tokens.borderRadius.medium.unit};
+  margin: 0;
+  padding: ${Tokens.sizes.spacing.large.value}${Tokens.sizes.spacing.large.unit};
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+`
+
+const StyledComment = styled('span')`
+  color: ${Tokens.colors.textSecondary.var};
+`
+
+const StyledKeyword = styled('span')`
+  color: ${Tokens.colors.rolePrompt.var};
+`
+
+const StyledIdentifier = styled('span')`
+  color: ${Tokens.colors.roleInfo.var};
+`
+
+const StyledKey = styled('span')`
+  color: ${Tokens.colors.roleHeading.var};
+`
+
+const StyledString = styled('span')`
+  color: ${Tokens.colors.roleSuccess.var};
+`
+
+export interface HeroConstField {
+  key: string
+  value: string
+}
+
+interface HeroConstDeclarationProps {
+  /** Filename comment header, e.g. `hero.tsx`. */
+  comment?: string
+  /** Variable name (defaults to `session`). */
+  identifier?: string
+  /** Object fields to render inside the const declaration. */
+  fields: ReadonlyArray<HeroConstField>
+}
+
+/**
+ * Static syntax-highlighted `const` declaration for the homepage hero. Phase 4
+ * ships the settled visual; Phase 5 will replace it with the animated
+ * `HeroTerminal` while keeping the same visual end-state. The declaration is
+ * decorative — `aria-hidden="true"` so the canonical `<h1>` remains the
+ * announced heading.
+ */
+export default function HeroConstDeclaration({
+  comment = 'hero.tsx',
+  identifier = 'session',
+  fields,
+}: HeroConstDeclarationProps) {
+  return (
+    <StyledPre aria-hidden="true">
+      <StyledComment>{`// ${comment}\n`}</StyledComment>
+      <StyledKeyword>const</StyledKeyword>
+      {' '}
+      <StyledIdentifier>{identifier}</StyledIdentifier>
+      {' = {\n'}
+      {fields.map((field, index) => (
+        <React.Fragment key={field.key}>
+          {'  '}
+          <StyledKey>{field.key}</StyledKey>
+          {': '}
+          <StyledString>{`'${field.value}'`}</StyledString>
+          {index < fields.length - 1 ? ',\n' : ',\n'}
+        </React.Fragment>
+      ))}
+      {'}'}
+    </StyledPre>
+  )
+}

--- a/src/components/chrome/MetaDate.test.tsx
+++ b/src/components/chrome/MetaDate.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import MetaDate from './MetaDate'
+
+describe('MetaDate', () => {
+  it('renders a <time> element with a parseable datetime attribute', () => {
+    render(<MetaDate dateString="2025-01-15T12:00:00.000Z" />)
+
+    const time = screen.getByText(/January\s+15,\s+2025/)
+    expect(time.tagName).toBe('TIME')
+    expect(time).toHaveAttribute('datetime', '2025-01-15T12:00:00.000Z')
+  })
+
+  it('formats the date with the default format string', () => {
+    render(<MetaDate dateString="2025-06-30T12:00:00.000Z" />)
+
+    expect(screen.getByText(/June\s+30,\s+2025/)).toBeInTheDocument()
+  })
+
+  it('honors a custom date-fns format string', () => {
+    render(
+      <MetaDate
+        dateString="2025-01-15T12:00:00.000Z"
+        formatString="yyyy"
+      />
+    )
+
+    expect(screen.getByText('2025')).toBeInTheDocument()
+  })
+})

--- a/src/components/chrome/MetaDate.tsx
+++ b/src/components/chrome/MetaDate.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { format } from 'date-fns'
+import { styled } from '@pigment-css/react'
+
+import Tokens from '@/lib/tokens'
+
+const StyledMetaDate = styled('time')`
+  font-family: ${Tokens.fonts.monospace.family};
+  font-size: ${Tokens.sizes.fonts.small.value}${Tokens.sizes.fonts.small.unit};
+  color: ${Tokens.colors.roleInfo.var};
+  letter-spacing: 0.02em;
+
+  &::before {
+    content: '// ';
+  }
+`
+
+interface MetaDateProps {
+  /** ISO-ish date string parseable by `new Date(...)`. */
+  dateString: string
+  /** date-fns format string. Defaults to `LLLL d, yyyy`. */
+  formatString?: string
+}
+
+/**
+ * Date metadata rendered with the refined-terminal chrome — cyan, monospaced,
+ * leading `// ` glyph. The component is the canonical date renderer for
+ * post and project preview cards, blog post headers, and any other
+ * "metadata" surface.
+ */
+export default function MetaDate({
+  dateString,
+  formatString = 'LLLL d, yyyy',
+}: MetaDateProps) {
+  return (
+    <StyledMetaDate dateTime={dateString}>
+      {format(new Date(dateString), formatString)}
+    </StyledMetaDate>
+  )
+}

--- a/src/components/chrome/PromptList.test.tsx
+++ b/src/components/chrome/PromptList.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import PromptList, { PromptItem } from './PromptList'
+
+describe('PromptList', () => {
+  it('renders a ul with the given aria-label', () => {
+    render(
+      <PromptList aria-label="Skills">
+        <PromptList.Item>React</PromptList.Item>
+        <PromptList.Item>TypeScript</PromptList.Item>
+      </PromptList>
+    )
+
+    const list = screen.getByRole('list', { name: 'Skills' })
+    expect(list.tagName).toBe('UL')
+    expect(screen.getAllByRole('listitem')).toHaveLength(2)
+  })
+
+  it('exposes PromptItem as both a static property and a named export', () => {
+    expect(PromptList.Item).toBe(PromptItem)
+  })
+
+  it('renders the children of each PromptItem', () => {
+    render(
+      <PromptList>
+        <PromptList.Item>Acme</PromptList.Item>
+        <PromptList.Item>Globex</PromptList.Item>
+      </PromptList>
+    )
+
+    expect(screen.getByText('Acme')).toBeInTheDocument()
+    expect(screen.getByText('Globex')).toBeInTheDocument()
+  })
+
+  it('forwards extra props to the underlying ul', () => {
+    render(
+      <PromptList data-testid="prompt-list">
+        <PromptList.Item>One</PromptList.Item>
+      </PromptList>
+    )
+
+    expect(screen.getByTestId('prompt-list')).toBeInTheDocument()
+  })
+})

--- a/src/components/chrome/PromptList.tsx
+++ b/src/components/chrome/PromptList.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { styled } from '@pigment-css/react'
+
+import Tokens from '@/lib/tokens'
+
+const StyledPromptList = styled('ul')`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${Tokens.sizes.spacing.xsmall.value}${Tokens.sizes.spacing.xsmall.unit};
+`
+
+const StyledPromptItem = styled('li')`
+  display: flex;
+  align-items: baseline;
+  gap: ${Tokens.sizes.spacing.xsmall.value}${Tokens.sizes.spacing.xsmall.unit};
+  margin: 0;
+  padding: 0;
+  color: ${Tokens.colors.roleBody.var};
+  line-height: 1.5;
+
+  &::before {
+    content: '>';
+    flex-shrink: 0;
+    width: 1ch;
+    font-family: ${Tokens.fonts.monospace.family};
+    color: ${Tokens.colors.roleSuccess.var};
+    font-weight: 600;
+  }
+`
+
+interface PromptListProps extends React.HTMLAttributes<HTMLUListElement> {
+  children: React.ReactNode
+}
+
+/**
+ * Refined-terminal list. Renders an unordered list whose items lead with a
+ * green `>` glyph (color reinforced by the glyph itself, never carrying
+ * meaning alone). Use `PromptList.Item` for items so styling stays
+ * encapsulated.
+ */
+function PromptList({ children, ...rest }: PromptListProps) {
+  return <StyledPromptList {...rest}>{children}</StyledPromptList>
+}
+
+interface PromptItemProps extends React.HTMLAttributes<HTMLLIElement> {
+  children: React.ReactNode
+}
+
+function PromptItem({ children, ...rest }: PromptItemProps) {
+  return <StyledPromptItem {...rest}>{children}</StyledPromptItem>
+}
+
+PromptList.Item = PromptItem
+
+export default PromptList
+export { PromptItem }

--- a/src/components/chrome/SectionHeading.test.tsx
+++ b/src/components/chrome/SectionHeading.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import SectionHeading from './SectionHeading'
+
+describe('SectionHeading', () => {
+  it('renders an h2 by default with the provided children as accessible name', () => {
+    render(<SectionHeading comment="skills.tsx">Skills</SectionHeading>)
+
+    const heading = screen.getByRole('heading', { name: 'Skills' })
+    expect(heading.tagName).toBe('H2')
+  })
+
+  it('renders an h3 when level=3', () => {
+    render(
+      <SectionHeading comment="nested.tsx" level={3}>
+        Nested
+      </SectionHeading>
+    )
+
+    const heading = screen.getByRole('heading', { name: 'Nested' })
+    expect(heading.tagName).toBe('H3')
+  })
+
+  it('renders the // comment line above the heading and marks it aria-hidden', () => {
+    const { container } = render(
+      <SectionHeading comment="experience.tsx">Experience</SectionHeading>
+    )
+
+    const comment = container.querySelector('[aria-hidden="true"]')
+    expect(comment).toHaveTextContent('// experience.tsx')
+  })
+
+  it('forwards id to the heading element', () => {
+    render(
+      <SectionHeading comment="recommendations.tsx" id="recommendations">
+        Recommendations
+      </SectionHeading>
+    )
+
+    const heading = screen.getByRole('heading', { name: 'Recommendations' })
+    expect(heading).toHaveAttribute('id', 'recommendations')
+  })
+})

--- a/src/components/chrome/SectionHeading.tsx
+++ b/src/components/chrome/SectionHeading.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import { styled } from '@pigment-css/react'
+
+import Tokens from '@/lib/tokens'
+
+const StyledSectionComment = styled('span')`
+  display: block;
+  font-family: ${Tokens.fonts.monospace.family};
+  font-size: ${Tokens.sizes.fonts.small.value}${Tokens.sizes.fonts.small.unit};
+  color: ${Tokens.colors.textSecondary.var};
+  margin-bottom: ${Tokens.sizes.xsmall.value}${Tokens.sizes.xsmall.unit};
+  letter-spacing: 0.02em;
+`
+
+const StyledHeadingWrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  margin: 0 0 ${Tokens.sizes.medium.value}${Tokens.sizes.medium.unit} 0;
+
+  h2,
+  h3 {
+    margin: 0;
+  }
+`
+
+export type SectionHeadingLevel = 2 | 3
+
+interface SectionHeadingProps {
+  /**
+   * The "filename" portion of the syntax-highlight chrome comment line,
+   * e.g. `skills.tsx`. Rendered as `// {comment}` above the heading and
+   * marked aria-hidden so the heading itself remains the announced label.
+   */
+  comment: string
+  /** Heading text. */
+  children: React.ReactNode
+  /** Heading level. Defaults to h2. h3 is supported for nested sections. */
+  level?: SectionHeadingLevel
+  /** Optional id forwarded to the heading element. */
+  id?: string
+  /** Optional aria-label forwarded to the heading element. */
+  'aria-label'?: string
+}
+
+/**
+ * Section heading with the refined-terminal "// section.tsx" comment header
+ * sitting above an h2/h3. Phase 4 syntax-highlight chrome — applied at every
+ * h2 across pages so prose still reads like a calm IDE.
+ */
+export default function SectionHeading({
+  comment,
+  children,
+  level = 2,
+  id,
+  ...rest
+}: SectionHeadingProps) {
+  const Heading = level === 3 ? 'h3' : 'h2'
+
+  return (
+    <StyledHeadingWrapper>
+      <StyledSectionComment aria-hidden="true">
+        {`// ${comment}`}
+      </StyledSectionComment>
+      <Heading id={id} {...rest}>
+        {children}
+      </Heading>
+    </StyledHeadingWrapper>
+  )
+}

--- a/src/components/chrome/TerminalButtonLink.test.tsx
+++ b/src/components/chrome/TerminalButtonLink.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import TerminalButtonLink from './TerminalButtonLink'
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+    ...rest
+  }: {
+    children: React.ReactNode
+    href: string
+    [key: string]: unknown
+  }) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    )
+  }
+})
+
+describe('TerminalButtonLink', () => {
+  it('renders an anchor pointing at href with the label as accessible name', () => {
+    render(<TerminalButtonLink href="/projects" label="Projects" />)
+
+    const link = screen.getByRole('link', { name: 'Projects' })
+    expect(link).toHaveAttribute('href', '/projects')
+    expect(screen.getByText('Projects')).toBeInTheDocument()
+  })
+
+  it('renders the description when provided', () => {
+    render(
+      <TerminalButtonLink
+        href="/about"
+        label="About"
+        description="Bio, skills, experience."
+      />
+    )
+
+    expect(screen.getByText('Bio, skills, experience.')).toBeInTheDocument()
+  })
+
+  it('omits the description node when no description is provided', () => {
+    render(<TerminalButtonLink href="/posts" label="Blog" />)
+
+    expect(screen.queryByText(/bio/i)).not.toBeInTheDocument()
+  })
+
+  it('honors an explicit aria-label override', () => {
+    render(
+      <TerminalButtonLink
+        href="/contact"
+        label="Contact"
+        aria-label="Open the contact page"
+      />
+    )
+
+    expect(
+      screen.getByRole('link', { name: 'Open the contact page' })
+    ).toHaveAttribute('href', '/contact')
+  })
+})

--- a/src/components/chrome/TerminalButtonLink.tsx
+++ b/src/components/chrome/TerminalButtonLink.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import Link from 'next/link'
+import { styled } from '@pigment-css/react'
+
+import Tokens from '@/lib/tokens'
+
+const StyledTerminalLink = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  gap: ${Tokens.sizes.spacing.xsmall.value}${Tokens.sizes.spacing.xsmall.unit};
+  padding: ${Tokens.sizes.large.value}${Tokens.sizes.large.unit};
+  border: 1px solid ${Tokens.colors.rolePrompt.var};
+  background-color: ${Tokens.colors.surfaceBase.var};
+  color: ${Tokens.colors.roleHeading.var};
+  font-family: ${Tokens.fonts.monospace.family};
+  text-decoration: none;
+  border-radius: ${Tokens.borderRadius.small.value}${Tokens.borderRadius.small.unit};
+  transition: background-color 0.15s ease, color 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    background-color: ${Tokens.colors.rolePrompt.var};
+    color: ${Tokens.colors.surfaceBase.var};
+    border-color: ${Tokens.colors.rolePrompt.var};
+  }
+`
+
+const StyledLabel = styled('span')`
+  font-weight: 600;
+  font-size: ${Tokens.sizes.medium.value}${Tokens.sizes.medium.unit};
+
+  &::before {
+    content: '[ ';
+    color: ${Tokens.colors.rolePrompt.var};
+    font-weight: 400;
+  }
+
+  &::after {
+    content: ' ]';
+    color: ${Tokens.colors.rolePrompt.var};
+    font-weight: 400;
+  }
+
+  ${StyledTerminalLink}:hover &::before,
+  ${StyledTerminalLink}:focus-visible &::before,
+  ${StyledTerminalLink}:hover &::after,
+  ${StyledTerminalLink}:focus-visible &::after {
+    color: ${Tokens.colors.surfaceBase.var};
+  }
+`
+
+const StyledDescription = styled('span')`
+  font-family: ${Tokens.fonts.body.family};
+  font-size: ${Tokens.sizes.fonts.small.value}${Tokens.sizes.fonts.small.unit};
+  color: ${Tokens.colors.roleBody.var};
+
+  ${StyledTerminalLink}:hover &,
+  ${StyledTerminalLink}:focus-visible & {
+    color: ${Tokens.colors.surfaceBase.var};
+  }
+`
+
+interface TerminalButtonLinkProps {
+  href: string
+  label: string
+  description?: string
+  'aria-label'?: string
+}
+
+/**
+ * Terminal-styled CTA link, presented like a `[ Label ]` button in monospaced
+ * type with a gold border and inverted hover/focus state. Used for the
+ * 3-doors row on `/` and any other primary terminal-style navigation.
+ */
+export default function TerminalButtonLink({
+  href,
+  label,
+  description,
+  'aria-label': ariaLabel,
+}: TerminalButtonLinkProps) {
+  return (
+    <StyledTerminalLink href={href} aria-label={ariaLabel}>
+      <StyledLabel>{label}</StyledLabel>
+      {description && <StyledDescription>{description}</StyledDescription>}
+    </StyledTerminalLink>
+  )
+}

--- a/src/components/chrome/index.ts
+++ b/src/components/chrome/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Refined-terminal "chrome" primitives — the small set of visual primitives
+ * that carry the syntax-highlight aesthetic across pages without scattering
+ * one-off styles into every component.
+ *
+ * Usage:
+ *   import { SectionHeading, PromptList, MetaDate, TerminalButtonLink,
+ *            HeroConstDeclaration } from '@/components/chrome'
+ */
+export { default as SectionHeading } from './SectionHeading'
+export type { SectionHeadingLevel } from './SectionHeading'
+export { default as PromptList, PromptItem } from './PromptList'
+export { default as MetaDate } from './MetaDate'
+export { default as TerminalButtonLink } from './TerminalButtonLink'
+export { default as HeroConstDeclaration } from './HeroConstDeclaration'
+export type { HeroConstField } from './HeroConstDeclaration'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily presentational refactors (markup/styling and small component swaps) with new test coverage; main risk is minor layout/accessibility regressions from changed DOM structure.
> 
> **Overview**
> Implements a new `components/chrome` set of refined-terminal primitives (`SectionHeading`, `PromptList`, `MetaDate`, `TerminalButtonLink`, `HeroConstDeclaration`) with accompanying unit tests, and exports them via `components/chrome/index.ts`.
> 
> Updates the homepage and About page to use `SectionHeading` for h2s, adds the static hero `const` declaration block, and restyles primary navigation “doors” to terminal-style CTAs. Refactors multiple content components (`ContactList`, `Skills`, `Positions`, `PostPreview`, `ProjectPreview`, and `ContentDate`) to adopt the new list/date/link chrome and tweaks reference company styling to match the new metadata look.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cb9b2e3c4c4052066236c91a8cc0faf9cb8dfc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->