### PR TITLE
Enhance useNavUser for cookie-backed auth state management

### DIFF
--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -26,9 +26,10 @@ This index is the first stop for contributors and agents. It maps the current mo
 - **Comment API** behavior belongs in `src/app/api/comments/**`; shared comment UI in `src/components/comments/**`.
 - **HTML sanitization** for user input: `src/lib/strip-html-tags.ts`.
 - **Reusable component styling** in `src/styles/common.tsx`.
+- **Header auth state** (`src/components/useNavUser.ts`): client Supabase session for `MainNavClient`; subscribes to `onAuthStateChange` and re-syncs from cookie storage on pathname changes so the nav updates after server-action sign-in without a full reload.
 
 ## Runtime Entry Points
-- `src/app/layout.tsx`: Root layout, metadata, navigation, footer, and global status banner.
+- `src/app/layout.tsx`: Root layout, metadata, `MainNav` (including `MainNavClient` + `useNavUser` for cookie-backed auth state), footer, and global status banner.
 - `src/app/page.tsx`: Homepage — reads projects, posts, and lastSong in parallel via `src/lib/content.ts`.
 - `src/middleware.ts`: Request middleware and Supabase session refresh.
 - `src/instrumentation.ts`: App instrumentation hook.

--- a/src/components/useNavUser.test.tsx
+++ b/src/components/useNavUser.test.tsx
@@ -1,0 +1,131 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useNavUser } from './useNavUser'
+
+const mockPathname = jest.fn(() => '/sign-in')
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname(),
+}))
+
+jest.mock('@/utils/supabase/client', () => ({
+  createClient: jest.fn(),
+}))
+
+const { createClient } = jest.requireMock<{
+  createClient: jest.Mock
+}>('@/utils/supabase/client')
+
+describe('useNavUser', () => {
+  let mockSupabase: {
+    auth: {
+      getSession: jest.Mock
+      refreshSession: jest.Mock
+      onAuthStateChange: jest.Mock
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPathname.mockReturnValue('/sign-in')
+    mockSupabase = {
+      auth: {
+        getSession: jest.fn(),
+        refreshSession: jest.fn(),
+        onAuthStateChange: jest.fn(),
+      },
+    }
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    })
+    mockSupabase.auth.refreshSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    })
+    mockSupabase.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: jest.fn() } },
+    })
+    createClient.mockReturnValue(mockSupabase)
+  })
+
+  it('loads initial session and stops loading', async () => {
+    const session = {
+      user: { id: 'u1', email: 'a@b.com' },
+    }
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session },
+      error: null,
+    })
+
+    const { result } = renderHook(() => useNavUser())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    expect(result.current.user).toEqual(session.user)
+    expect(mockSupabase.auth.getSession).toHaveBeenCalled()
+  })
+
+  it('re-syncs session when pathname changes after first render', async () => {
+    const loggedInSession = {
+      user: { id: 'u1', email: 'a@b.com' },
+    }
+    mockSupabase.auth.refreshSession.mockResolvedValue({
+      data: { session: loggedInSession },
+      error: null,
+    })
+
+    const { result, rerender } = renderHook(() => useNavUser())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    mockPathname.mockReturnValue('/profile')
+    await act(async () => {
+      rerender()
+    })
+
+    await waitFor(() => {
+      expect(mockSupabase.auth.refreshSession).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(result.current.user).toEqual(loggedInSession.user)
+    })
+  })
+
+  it('falls back to getSession when refreshSession returns an error', async () => {
+    const fallbackSession = {
+      user: { id: 'u2', email: 'c@d.com' },
+    }
+    mockSupabase.auth.refreshSession.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'refresh failed' },
+    })
+    mockSupabase.auth.getSession
+      .mockResolvedValueOnce({
+        data: { session: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { session: fallbackSession },
+        error: null,
+      })
+
+    const { result, rerender } = renderHook(() => useNavUser())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    mockPathname.mockReturnValue('/profile')
+    await act(async () => {
+      rerender()
+    })
+
+    await waitFor(() => {
+      expect(result.current.user).toEqual(fallbackSession.user)
+    })
+    expect(mockSupabase.auth.getSession).toHaveBeenCalled()
+  })
+})

--- a/src/components/useNavUser.ts
+++ b/src/components/useNavUser.ts
@@ -1,12 +1,23 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { User } from '@supabase/supabase-js'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { usePathname } from 'next/navigation'
+import type { Session, User } from '@supabase/supabase-js'
 import { createClient } from '@/utils/supabase/client'
 
 export function useNavUser(): { user: User | null; isLoading: boolean } {
+  const pathname = usePathname()
+  const prevPathnameRef = useRef<string | undefined>(undefined)
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+
+  const applySession = useCallback((session: Session | null) => {
+    const newUser = session?.user ?? null
+    setUser((prev) => {
+      if (prev?.id === newUser?.id) return prev
+      return newUser
+    })
+  }, [])
 
   useEffect(() => {
     const supabase = createClient()
@@ -16,7 +27,7 @@ export function useNavUser(): { user: User | null; isLoading: boolean } {
         const {
           data: { session },
         } = await supabase.auth.getSession()
-        setUser(session?.user || null)
+        applySession(session)
       } catch (error) {
         console.error('Error getting session:', error)
       } finally {
@@ -29,15 +40,52 @@ export function useNavUser(): { user: User | null; isLoading: boolean } {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      const newUser = session?.user || null
-      setUser((prev) => {
-        if (prev?.id === newUser?.id) return prev
-        return newUser
-      })
+      applySession(session)
     })
 
     return () => subscription.unsubscribe()
-  }, [])
+  }, [applySession])
+
+  /**
+   * Server actions (e.g. sign-in) set session cookies and redirect. The
+   * singleton browser client may not emit auth events for that update, so
+   * re-load the session from cookie storage when the route changes.
+   */
+  useEffect(() => {
+    if (prevPathnameRef.current === undefined) {
+      prevPathnameRef.current = pathname
+      return
+    }
+    if (prevPathnameRef.current === pathname) {
+      return
+    }
+    prevPathnameRef.current = pathname
+
+    const supabase = createClient()
+    let cancelled = false
+
+    const resyncSession = async () => {
+      try {
+        const { data, error } = await supabase.auth.refreshSession()
+        if (cancelled) return
+        if (error) {
+          const {
+            data: { session },
+          } = await supabase.auth.getSession()
+          if (!cancelled) applySession(session ?? null)
+          return
+        }
+        applySession(data.session ?? null)
+      } catch (error) {
+        console.error('Error syncing session after navigation:', error)
+      }
+    }
+
+    void resyncSession()
+    return () => {
+      cancelled = true
+    }
+  }, [pathname, applySession])
 
   return { user, isLoading }
 }


### PR DESCRIPTION
- Updated `useNavUser` to include pathname tracking and session resynchronization on navigation changes, improving user experience during authentication state updates.
- Added tests for `useNavUser` to ensure correct session loading and re-sync behavior when the pathname changes, enhancing reliability and coverage.
- Updated documentation in `PROJECT_INDEX.md` to reflect the new header auth state management and its integration with `MainNavClient`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side auth/session state used for navigation UI; incorrect resyncing could cause stale or flashing signed-in state across route transitions. Scope is limited to a single hook with added unit tests and doc updates.
> 
> **Overview**
> Updates `useNavUser` to keep the header’s user state in sync with cookie-backed Supabase sessions by reloading the session on pathname changes (using `refreshSession` with a `getSession` fallback) in addition to the existing `onAuthStateChange` subscription.
> 
> Adds Jest hook tests covering initial session load, session re-sync on navigation, and the refresh-error fallback path, and updates `PROJECT_INDEX.md` to document the new header auth-state behavior and its use from `layout.tsx`/`MainNavClient`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6775887efcbb34acd77b04f277f2893987fb73e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->